### PR TITLE
Remove brod module reference; it does not implement correct functions

### DIFF
--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -4,6 +4,5 @@
   {vsn,"1.1"},
   {registered,[]},
   {applications,[kernel,stdlib]},
-  {mod,{brod,[]}},
   {env,[]},
   {modules,[]}]}.


### PR DESCRIPTION
As it stands, the brod module does not actually implement the start function required when one does something like:

application:start(brod).
