### PR TITLE
Rename start_* to start_link_* in brod's api

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Why "brod"? [http://en.wikipedia.org/wiki/Max_Brod](http://en.wikipedia.org/wiki
 In gen_server's init/1:
 
     % Producer will be linked to the calling process
-    {ok, Producer} = brod:start_producer(Hosts, RequiredAcks, AckTimeout),
+    {ok, Producer} = brod:start_link_producer(Hosts, RequiredAcks, AckTimeout),
     {ok, #state{ producer = Producer }}.
 
 Sending a message:
@@ -44,7 +44,7 @@ Include brod.hrl:
 In gen_server's init/1:
 
     % Consumer will be linked to the calling process
-    {ok, Consumer} = brod:start_consumer(Hosts, Topic, Partition),
+    {ok, Consumer} = brod:start_link_consumer(Hosts, Topic, Partition),
     ok = brod:consume(Consumer, self(), Offset, 1000, 0, 100000),
     {ok, #state{ consumer = Consumer }}.
 
@@ -63,8 +63,8 @@ Handling payloads from kafka broker:
     Key = <<"key">>.
     Value = <<"value">>.
     Partition = 0.
-    {ok, Producer} = brod:start_producer(Hosts).
-    {ok, Consumer} = brod:start_consumer(Hosts, Topic, Partition).
+    {ok, Producer} = brod:start_link_producer(Hosts).
+    {ok, Consumer} = brod:start_link_consumer(Hosts, Topic, Partition).
     ok = brod:consume(Consumer, -1).
     {ok, Ref} = brod:produce(Producer, Topic, Partition, Key, Value).
     receive {{Ref, Producer}, ack} -> ok end.

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -25,6 +25,8 @@
 %% Producer API
 -export([ start_link_producer/1
         , start_link_producer/3
+        , start_producer/1
+        , start_producer/3
         , stop_producer/1
         , produce/3
         , produce/4
@@ -36,6 +38,7 @@
 
 %% Consumer API
 -export([ start_link_consumer/3
+        , start_consumer/3
         , stop_consumer/1
         , consume/2
         , consume/6
@@ -66,6 +69,19 @@
 -define(DEFAULT_ACK_TIMEOUT,  1000). % default broker ack timeout
 
 %%%_* API ----------------------------------------------------------------------
+%% @deprecated
+%% @equiv start_link_producer(Hosts)
+-spec start_producer([host()]) -> {ok, pid()} | {error, any()}.
+start_producer(Hosts) ->
+  start_link_producer(Hosts).
+
+%% @deprecated
+%% @equiv start_link_producer(Hosts, RequiredAcks, AckTimeout)
+-spec start_producer([host()], integer(), integer()) ->
+                   {ok, pid()} | {error, any()}.
+start_producer(Hosts, RequiredAcks, AckTimeout) ->
+  start_link_producer(Hosts, RequiredAcks, AckTimeout).
+
 %% @equiv start_link_producer(Hosts, 1, 1000)
 -spec start_link_producer([host()]) -> {ok, pid()} | {error, any()}.
 start_link_producer(Hosts) ->
@@ -153,6 +169,13 @@ produce_sync(Pid, Topic, Partition, KVList) when is_list(KVList) ->
       erlang:demonitor(MonitorRef, [flush]),
       ok
   end.
+
+%% @deprecated
+%% @equiv start_link_consumer(Hosts, Topic, Partition)
+-spec start_consumer([host()], binary(), integer()) ->
+                   {ok, pid()} | {error, any()}.
+start_consumer(Hosts, Topic, Partition) ->
+  start_link_consumer(Hosts, Topic, Partition).
 
 %% @doc Start consumer process
 -spec start_link_consumer([host()], binary(), integer()) ->

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -23,8 +23,8 @@
 -module(brod).
 
 %% Producer API
--export([ start_producer/1
-        , start_producer/3
+-export([ start_link_producer/1
+        , start_link_producer/3
         , stop_producer/1
         , produce/3
         , produce/4
@@ -35,7 +35,7 @@
         ]).
 
 %% Consumer API
--export([ start_consumer/3
+-export([ start_link_consumer/3
         , stop_consumer/1
         , consume/2
         , consume/6
@@ -66,10 +66,10 @@
 -define(DEFAULT_ACK_TIMEOUT,  1000). % default broker ack timeout
 
 %%%_* API ----------------------------------------------------------------------
-%% @equiv start_producer(Hosts, 1, 1000)
--spec start_producer([host()]) -> {ok, pid()} | {error, any()}.
-start_producer(Hosts) ->
-  start_producer(Hosts, ?DEFAULT_ACKS, ?DEFAULT_ACK_TIMEOUT).
+%% @equiv start_link_producer(Hosts, 1, 1000)
+-spec start_link_producer([host()]) -> {ok, pid()} | {error, any()}.
+start_link_producer(Hosts) ->
+  start_link_producer(Hosts, ?DEFAULT_ACKS, ?DEFAULT_ACK_TIMEOUT).
 
 %% @doc Start a process to publish messages to kafka.
 %%      Hosts:
@@ -98,9 +98,9 @@ start_producer(Hosts) ->
 %%        time will not be included, (3) we will not terminate a
 %%        local write so if the local write time exceeds this
 %%        timeout it will not be respected.
--spec start_producer([host()], integer(), integer()) ->
+-spec start_link_producer([host()], integer(), integer()) ->
                         {ok, pid()} | {error, any()}.
-start_producer(Hosts, RequiredAcks, AckTimeout) ->
+start_link_producer(Hosts, RequiredAcks, AckTimeout) ->
   brod_producer:start_link(Hosts, RequiredAcks, AckTimeout).
 
 %% @doc Stop producer process
@@ -155,9 +155,9 @@ produce_sync(Pid, Topic, Partition, KVList) when is_list(KVList) ->
   end.
 
 %% @doc Start consumer process
--spec start_consumer([host()], binary(), integer()) ->
+-spec start_link_consumer([host()], binary(), integer()) ->
                         {ok, pid()} | {error, any()}.
-start_consumer(Hosts, Topic, Partition) ->
+start_link_consumer(Hosts, Topic, Partition) ->
   brod_consumer:start_link(Hosts, Topic, Partition).
 
 %% @doc Stop consumer process
@@ -281,7 +281,7 @@ file_consumer(Hosts, Topic, Partition, Offset, Filename) ->
   C.
 
 simple_consumer(Hosts, Topic, Partition, Offset, Io) ->
-  {ok, C} = brod:start_consumer(Hosts, Topic, Partition),
+  {ok, C} = brod:start_link_consumer(Hosts, Topic, Partition),
   Pid = proc_lib:spawn_link(fun() -> simple_consumer_loop(C, Io) end),
   ok = brod:consume(C, Pid, Offset, 1000, 0, 100000),
   Pid.


### PR DESCRIPTION
Let the API reflect the semantics of starting a producer and consumer process: The OTP libraries offer both `start` and `start_link`, let us mimic its interface and follow the principle of least surprise.
