### PR TITLE
Remove timeouts from gen_server calls

### DIFF
--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Kafka client"},
-  {vsn,"1.5.0"},
+  {vsn,"1.5.2"},
   {registered,[]},
   {applications,[kernel,stdlib]},
   {env,[]},

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -86,13 +86,14 @@ start_link(Hosts, Topic, Partition, SleepTimeout, Debug) ->
 
 -spec stop(pid()) -> ok | {error, any()}.
 stop(Pid) ->
-  gen_server:call(Pid, stop).
+  gen_server:call(Pid, stop, infinity).
 
 -spec consume(pid(), callback_fun(), integer(), integer(),
               integer(), integer()) -> ok | {error, any()}.
 consume(Pid, Callback, Offset, MaxWaitTime, MinBytes, MaxBytes) ->
   gen_server:call(Pid, {consume, Callback, Offset,
-                        MaxWaitTime, MinBytes, MaxBytes}).
+                        MaxWaitTime, MinBytes, MaxBytes},
+                  infinity).
 
 -spec debug(pid(), print | string() | none) -> ok.
 %% @doc Enable debugging on consumer and its connection to a broker
@@ -112,7 +113,7 @@ no_debug(Pid) ->
 
 -spec get_socket(pid()) -> {ok, #socket{}}.
 get_socket(Pid) ->
-  gen_server:call(Pid, get_socket).
+  gen_server:call(Pid, get_socket, infinity).
 
 %%%_* gen_server callbacks -----------------------------------------------------
 init([Hosts, Topic, Partition, SleepTimeout, Debug]) ->
@@ -278,8 +279,8 @@ exec_callback(Callback, MessageSet) ->
 
 do_debug(Pid, Debug) ->
   {ok, #socket{pid = Sock}} = get_socket(Pid),
-  {ok, _} = gen:call(Sock, system, {debug, Debug}),
-  {ok, _} = gen:call(Pid, system, {debug, Debug}),
+  {ok, _} = gen:call(Sock, system, {debug, Debug}, infinity),
+  {ok, _} = gen:call(Pid, system, {debug, Debug}, infinity),
   ok.
 
 %% Tests -----------------------------------------------------------------------

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -99,14 +99,15 @@ start_link(Hosts, RequiredAcks, AckTimeout, ClientId, Debug) ->
 
 -spec stop(pid()) -> ok | {error, any()}.
 stop(Pid) ->
-  gen_server:call(Pid, stop).
+  gen_server:call(Pid, stop, infinity).
 
 -spec produce(pid(), binary(), integer(), [{binary(), binary()}]) ->
                  {ok, reference()}.
 produce(Pid, Topic, Partition, KVList) ->
   Sender = self(),
   Ref = erlang:make_ref(),
-  gen_server:call(Pid, {produce, Sender, Ref, Topic, Partition, KVList}).
+  gen_server:call(Pid, {produce, Sender, Ref, Topic, Partition, KVList},
+                  infinity).
 
 -spec debug(pid(), print | string() | none) -> ok.
 %% @doc Enable debugging on producer and its connection to a broker
@@ -126,7 +127,7 @@ no_debug(Pid) ->
 
 -spec get_sockets(pid()) -> {ok, [#socket{}]}.
 get_sockets(Pid) ->
-  gen_server:call(Pid, get_sockets).
+  gen_server:call(Pid, get_sockets, infinity).
 
 %%%_* gen_server callbacks -----------------------------------------------------
 init([Hosts, RequiredAcks, AckTimeout, ClientId, Debug]) ->
@@ -341,9 +342,9 @@ do_debug(Pid, Debug) ->
   {ok, Sockets} = get_sockets(Pid),
   lists:foreach(
     fun(#socket{pid = SocketPid}) ->
-        {ok, _} = gen:call(SocketPid, system, {debug, Debug})
+        {ok, _} = gen:call(SocketPid, system, {debug, Debug}, infinity)
     end, Sockets),
-  {ok, _} = gen:call(Pid, system, {debug, Debug}),
+  {ok, _} = gen:call(Pid, system, {debug, Debug}, infinity),
   ok.
 
 ensure_binary(A) when is_atom(A)   -> ensure_binary(atom_to_list(A));


### PR DESCRIPTION
Both the consumer and the producer may attempt to connect to several Kafka nodes when handling requests. In case of network hiccups or Kafka nodes being unavailable such operations may take many seconds.
Therefore it's better not to use 5 second timeouts in calls to these processes.
