### PR TITLE
Start client on demand under supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Why "brod"? [http://en.wikipedia.org/wiki/Max_Brod](http://en.wikipedia.org/wiki
 "client" in brod is a process responsible for establishing and maintaining
 connections to kafka cluster. It also manages producer and consumer processes.
 
-You can use brod:start_link_client/1,2,3 to start a client on demand,
+You can use brod:start_client/1,2,3 to start a client on demand,
 or include its configuration in sys.config.
 
 A required parameter for client is kafka endpoint(s).
@@ -44,9 +44,7 @@ Example of configuration (for sys.config):
    [ { clients
      , [ { brod_client_1 %% registered name
          , [ { endpoints, [{"localhost", 9092}]}
-           , { config
-             , [ {reconnect_cool_down_seconds, 10}] %% connection error
-             }
+           , { reconnect_cool_down_seconds, 10} %% connection error
            ]
          }
        ]
@@ -60,11 +58,7 @@ Example of configuration (for sys.config):
 ## Start brod client on demand
 
     ClientConfig = [{reconnect_cool_down_seconds, 10}],
-    {ok, ClientPid} = brod:start_link_client([{"localhost", 9092}], brod_client_1, ClientConfig).
-
-Or the simplest option:
-
-    {ok, ClientPid} = brod:start_link_client([{"localhost", 9092}]).
+    ok = brod:start_client([{"localhost", 9092}], brod_client_1, ClientConfig).
 
 ## Producer
 
@@ -78,14 +72,14 @@ Put below configs to client config in sys.config or app env:
 
 ### Start a producer on demand
 
-    brod:start_producer(_Client         = brod_client_1, %% may also be ClientPid,
+    brod:start_producer(_Client         = brod_client_1,
                         _Topic          = <<"brod-test-topic-1">>,
                         _ProducerConfig = []).
 
 ### Produce to a known topic-partition:
 
     {ok, CallRef} =
-      brod:produce(_Client    = brod_client_1, %% may also be ClientPid
+      brod:produce(_Client    = brod_client_1,
                    _Topic     = <<"brod-test-topic-1">>,
                    _Partition = 0
                    _Key       = <<"some-key">>
@@ -106,7 +100,7 @@ Put below configs to client config in sys.config or app env:
 Block calling process until Kafka confirmed the message:
 
     {ok, CallRef} =
-      brod:produce(_Client    = brod_client_1, %% may also be ClientPid
+      brod:produce(_Client    = brod_client_1,
                    _Topic     = <<"brod-test-topic-1">>,
                    _Partition = 0
                    _Key       = <<"some-key">>
@@ -115,7 +109,7 @@ Block calling process until Kafka confirmed the message:
 
 or the same in one call:
 
-    brod:produce_sync(_Client    = brod_client_1, %% may also be ClientPid
+    brod:produce_sync(_Client    = brod_client_1,
                       _Topic     = <<"brod-test-topic-1">>,
                       _Partition = 0
                       _Key       = <<"some-key">>
@@ -123,7 +117,7 @@ or the same in one call:
 
 ### Produce with random partitioner
 
-    Client = brod_client_1, %% may also be ClientPid
+    Client = brod_client_1,
     Topic  = <<"brod-test-topic-1">>,
     PartitionFun = fun(_Topic, PartitionsCount, _Key, _Value) ->
                        {ok, crypto:rand_uniform(0, PartitionsCount)}
@@ -173,7 +167,7 @@ Find more examples in test/ (brod\_demo\_*).
       {ok, ack, State}.
 
     init() ->
-      Client = brod_client_1, %% may also be ClientPid
+      Client = brod_client_1,
       Topic  = <<"brod-test-topic-1">>,
       %% commit offsets to kafka every 5 seconds
       GroupConfig = [{offset_commit_policy, commit_to_kafka_v2}

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -134,7 +134,6 @@ stop(Client) ->
       ok
   end.
 
-
 %% @doc Get producer of the given topic-partition.
 %% The producer is started if auto_start_producers is
 %% enabled in client config.
@@ -783,7 +782,7 @@ maybe_start_producer(Client, Topic, Partition, Error) ->
                                         | {error, any()}.
 send_sync(State, Request, Timeout) ->
   #state{config = Config} = State,
-  MaxRetry = proplists:get_value(get_metadata_timout_seconds, Config,
+  MaxRetry = proplists:get_value(max_metadata_sock_retry, Config,
                                  ?DEFAULT_MAX_METADATA_SOCK_RETRY),
   send_sync(State, Request, Timeout, MaxRetry).
 

--- a/test/brod_demo_group_subscriber_koc.erl
+++ b/test/brod_demo_group_subscriber_koc.erl
@@ -65,8 +65,8 @@ bootstrap(DelaySeconds) ->
   BootstrapHosts = [{"localhost", 9092}],
   ClientConfig = [],
   Topic = <<"brod-demo-group-subscriber-koc">>,
-  {ok, _ClientPid} =
-    brod:start_link_client(BootstrapHosts, ClientId, ClientConfig),
+  {ok, _} = application:ensure_all_started(brod),
+  ok = brod:start_client(BootstrapHosts, ClientId, ClientConfig),
   ok = brod:start_producer(ClientId, Topic, _ProducerConfig = []),
   {ok, PartitionCount} = brod:get_partitions_count(ClientId, Topic),
   Partitions = lists:seq(0, PartitionCount - 1),

--- a/test/brod_demo_group_subscriber_loc.erl
+++ b/test/brod_demo_group_subscriber_loc.erl
@@ -71,8 +71,8 @@ bootstrap(DelaySeconds) ->
   ClientConfig = [],
   Topic = <<"brod-demo-group-subscriber-loc">>,
   GroupId = iolist_to_binary([Topic, "-group-id"]),
-  {ok, _ClientPid} =
-    brod:start_link_client(BootstrapHosts, ClientId, ClientConfig),
+  {ok, _} = application:ensure_all_started(brod),
+  ok = brod:start_client(BootstrapHosts, ClientId, ClientConfig),
   ok = brod:start_producer(ClientId, Topic, _ProducerConfig = []),
   {ok, PartitionCount} = brod:get_partitions_count(ClientId, Topic),
   Partitions = lists:seq(0, PartitionCount - 1),

--- a/test/brod_demo_topic_subscriber.erl
+++ b/test/brod_demo_topic_subscriber.erl
@@ -65,8 +65,8 @@ bootstrap(DelaySeconds) ->
   BootstrapHosts = [{"localhost", 9092}],
   ClientConfig = [],
   Topic = <<"brod-demo-topic-subscriber">>,
-  {ok, _ClientPid} =
-    brod:start_link_client(BootstrapHosts, ClientId, ClientConfig),
+  {ok, _} = application:ensure_all_started(brod),
+  ok = brod:start_client(BootstrapHosts, ClientId, ClientConfig),
   ok = brod:start_producer(ClientId, Topic, _ProducerConfig = []),
   {ok, _Pid} = spawn_consumer(ClientId, Topic),
   {ok, PartitionCount} = brod:get_partitions_count(ClientId, Topic),

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -58,7 +58,9 @@
 
 suite() -> [{timetrap, {seconds, 30}}].
 
-init_per_suite(Config) -> Config.
+init_per_suite(Config) ->
+  {ok, _} = application:ensure_all_started(brod),
+  Config.
 
 end_per_suite(_Config) -> ok.
 
@@ -68,8 +70,7 @@ init_per_testcase(Case, Config) ->
   BootstrapHosts = [{"localhost", 9092}],
   ClientConfig   = [],
   Topic          = ?TOPIC,
-  {ok, _ClientPid} =
-    brod:start_link_client(BootstrapHosts, ClientId, ClientConfig),
+  ok = brod:start_client(BootstrapHosts, ClientId, ClientConfig),
   ok = brod:start_producer(ClientId, Topic, _ProducerConfig = []),
   Config.
 

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -67,35 +67,33 @@ subscriber_loop(Client, TesterPid) ->
 
 suite() -> [{timetrap, {seconds, 30}}].
 
-init_per_suite(Config) -> Config.
+init_per_suite(Config) ->
+  {ok, _} = application:ensure_all_started(brod),
+  Config.
 
 end_per_suite(_Config) -> ok.
 
 init_per_testcase(Case, Config) ->
   Client = Case,
   Topic = ?TOPIC,
-  case whereis(Client) of
-    ?undef -> ok;
-    Pid_   -> brod:stop_client(Pid_)
-  end,
+  brod:stop_client(Client),
   TesterPid = self(),
-  {ok, ClientPid} = brod:start_link_client(?HOSTS, Client),
+  ok = brod:start_client(?HOSTS, Client),
   ok = brod:start_producer(Client, Topic, []),
   ok = brod:start_consumer(Client, Topic, []),
   Subscriber = spawn_link(fun() -> subscriber_loop(Client, TesterPid) end),
   {ok, _ConsumerPid1} = brod:subscribe(Client, Subscriber, Topic, 0, []),
   {ok, _ConsumerPid2} = brod:subscribe(Client, Subscriber, Topic, 1, []),
-  [{client, Client}, {client_pid, ClientPid},
-   {subscriber, Subscriber} | Config].
+  [{client, Client}, {subscriber, Subscriber} | Config].
 
 end_per_testcase(_Case, Config) ->
   Subscriber = ?config(subscriber),
   unlink(Subscriber),
   exit(Subscriber, kill),
-  Pid = ?config(client_pid),
+  Pid = whereis(?config(client)),
   try
     Ref = erlang:monitor(process, Pid),
-    brod:stop_client(Pid),
+    brod:stop_client(?config(client)),
     receive
       {'DOWN', Ref, process, Pid, _} -> ok
     end
@@ -160,8 +158,7 @@ t_producer_topic_not_found(Config) when is_list(Config) ->
 
 
 t_producer_partition_not_found(Config) when is_list(Config) ->
-  Client = whereis(t_producer_partition_not_found),
-  ?assert(is_pid(Client)),
+  Client = whereis(?config(client)),
   ?assertEqual({error, {producer_not_found, ?TOPIC, 100}},
                brod:produce(Client, ?TOPIC, 100, <<"k">>, <<"v">>)).
 

--- a/test/brod_topic_subscriber_SUITE.erl
+++ b/test/brod_topic_subscriber_SUITE.erl
@@ -55,7 +55,9 @@
 
 suite() -> [{timetrap, {seconds, 30}}].
 
-init_per_suite(Config) -> Config.
+init_per_suite(Config) ->
+  {ok, _} = application:ensure_all_started(brod),
+  Config.
 
 end_per_suite(_Config) -> ok.
 
@@ -65,8 +67,7 @@ init_per_testcase(Case, Config) ->
   BootstrapHosts = [{"localhost", 9092}],
   ClientConfig   = [],
   Topic          = ?TOPIC,
-  {ok, _ClientPid} =
-    brod:start_link_client(BootstrapHosts, ClientId, ClientConfig),
+  ok = brod:start_client(BootstrapHosts, ClientId, ClientConfig),
   ok = brod:start_producer(ClientId, Topic, _ProducerConfig = []),
   Config.
 


### PR DESCRIPTION
One can use brod_client:start_link if they know what they are doing.
