### PR TITLE
Fix specs: clients ids should have type brod_client_id() (i.e. atom()), not …

### DIFF
--- a/src/brod.erl
+++ b/src/brod.erl
@@ -106,7 +106,7 @@ start_client(BootstrapEndpoints) ->
   start_client(BootstrapEndpoints, ?BROD_DEFAULT_CLIENT_ID).
 
 %% @equiv stat_client(BootstrapEndpoints, ClientId, [])
--spec start_client([endpoint()], client_id()) ->
+-spec start_client([endpoint()], brod_client_id()) ->
                            ok | {error, any()}.
 start_client(BootstrapEndpoints, ClientId) ->
   start_client(BootstrapEndpoints, ClientId, []).
@@ -147,7 +147,7 @@ start_client(BootstrapEndpoints, ClientId) ->
 %%       Producer configuration to use when auto_start_producers is true.
 %%       @see brod_client:start_producer/3. for more details.
 %% @end
--spec start_client([endpoint()], client_id(), client_config()) ->
+-spec start_client([endpoint()], brod_client_id(), client_config()) ->
                       ok | {error, any()}.
 start_client(BootstrapEndpoints, ClientId, Config) ->
   brod_sup:start_client(BootstrapEndpoints, ClientId, Config).
@@ -158,12 +158,12 @@ start_link_client(BootstrapEndpoints) ->
   start_link_client(BootstrapEndpoints, ?BROD_DEFAULT_CLIENT_ID).
 
 %% @equiv stat_link_client(BootstrapEndpoints, ClientId, [])
--spec start_link_client([endpoint()], client_id()) ->
+-spec start_link_client([endpoint()], brod_client_id()) ->
                            {ok, pid()} | {error, any()}.
 start_link_client(BootstrapEndpoints, ClientId) ->
   start_link_client(BootstrapEndpoints, ClientId, []).
 
--spec start_link_client([endpoint()], client_id(), client_config()) ->
+-spec start_link_client([endpoint()], brod_client_id(), client_config()) ->
                            {ok, pid()} | {error, any()}.
 start_link_client(BootstrapEndpoints, ClientId, Config) ->
   brod_client:start_link(BootstrapEndpoints, ClientId, Config).

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -100,7 +100,7 @@
         }).
 
 -record(state,
-        { client_id            :: client_id()
+        { client_id            :: brod_client_id()
         , bootstrap_endpoints  :: [endpoint()]
         , meta_sock_pid        :: pid()
         , payload_sockets = [] :: [#sock{}]
@@ -119,7 +119,7 @@ start_link(BootstrapEndpoints, Config) ->
   gen_server:start_link(?MODULE, Args, []).
 
 -spec start_link( [endpoint()]
-                , client_id()
+                , brod_client_id()
                 , client_config()) -> {ok, pid()} | {error, any()}.
 start_link(BootstrapEndpoints, ClientId, Config) when is_atom(ClientId) ->
   Args = {BootstrapEndpoints, ClientId, Config},
@@ -672,7 +672,7 @@ is_cooled_down(Ts, #state{config = Config}) ->
 %% NOTE: crash in case failed to connect to all of the endpoints.
 %%       should be restarted by supervisor.
 %% @end
--spec start_metadata_socket(client_id(), [endpoint()]) ->
+-spec start_metadata_socket(brod_client_id(), [endpoint()]) ->
                                {ok, pid(),  [endpoint()]} | no_return().
 start_metadata_socket(ClientId, [_|_] = Endpoints) ->
   start_metadata_socket(ClientId, Endpoints,

--- a/src/brod_int.hrl
+++ b/src/brod_int.hrl
@@ -37,7 +37,7 @@
 -type producer_config()  :: brod_producer_config().
 -type consumer_config()  :: brod_consumer_config().
 -type consumer_options() :: [{consumer_option(), integer()}].
--type client()           :: client_id() | pid().
+-type client()           :: brod_client_id() | pid().
 -type required_acks()    :: -1..1.
 
 %% consumer groups

--- a/src/brod_sock.erl
+++ b/src/brod_sock.erl
@@ -59,7 +59,7 @@
                }).
 
 %%%_* API ======================================================================
--spec start_link(pid(), string(), integer(), client_id() | binary(), term()) ->
+-spec start_link(pid(), string(), integer(), brod_client_id() | binary(), term()) ->
                     {ok, pid()} | {error, any()}.
 start_link(Parent, Host, Port, ClientId, Debug) when is_atom(ClientId) ->
   BinClientId = list_to_binary(atom_to_list(ClientId)),
@@ -67,7 +67,7 @@ start_link(Parent, Host, Port, ClientId, Debug) when is_atom(ClientId) ->
 start_link(Parent, Host, Port, ClientId, Debug) when is_binary(ClientId) ->
   proc_lib:start_link(?MODULE, init, [Parent, Host, Port, ClientId, Debug]).
 
--spec start(pid(), string(), integer(), client_id() | binary(), term()) ->
+-spec start(pid(), string(), integer(), brod_client_id() | binary(), term()) ->
                {ok, pid()} | {error, any()}.
 start(Parent, Host, Port, ClientId, Debug) when is_atom(ClientId) ->
   BinClientId = list_to_binary(atom_to_list(ClientId)),

--- a/src/brod_sup.erl
+++ b/src/brod_sup.erl
@@ -105,7 +105,7 @@
 start_link() ->
   supervisor3:start_link({local, ?SUP}, ?MODULE, clients_sup).
 
--spec start_client([endpoint()], client_id(), client_config()) ->
+-spec start_client([endpoint()], brod_client_id(), client_config()) ->
                       ok | {error, any()}.
 start_client(Endpoints, ClientId, Config) ->
   ClientSpec = client_spec(Endpoints, ClientId, Config),
@@ -114,12 +114,12 @@ start_client(Endpoints, ClientId, Config) ->
     Error      -> Error
   end.
 
--spec stop_client(client_id()) -> ok | {error, any()}.
+-spec stop_client(brod_client_id()) -> ok | {error, any()}.
 stop_client(ClientId) ->
   supervisor3:terminate_child(?SUP, ClientId),
   supervisor3:delete_child(?SUP, ClientId).
 
--spec find_client(client_id()) -> [pid()].
+-spec find_client(brod_client_id()) -> [pid()].
 find_client(Client) ->
   supervisor3:find_child(?SUP, Client).
 


### PR DESCRIPTION
…client_id() (which is string(), and only exists in the kafka_protocol library in any case)

This was causing a dialyzer error when I attempted to use the client. I believe the problem arose due to confusion between client_id() and brod_client_id(). I think all references within the brod code should be to brod_client_id(), and I think this PR makes all the needed changes.
