### PR TITLE
remove brod_client:start_link/2

### DIFF
--- a/src/brod.erl
+++ b/src/brod.erl
@@ -35,12 +35,15 @@
         , start_client/1
         , start_client/2
         , start_client/3
-        , start_link_client/1
-        , start_link_client/2
-        , start_link_client/3
         , start_consumer/3
         , start_producer/3
         , stop_client/1
+        ]).
+
+%% Client API (deprecated)
+-export([ start_link_client/1
+        , start_link_client/2
+        , start_link_client/3
         ]).
 
 %% Producer API
@@ -501,7 +504,8 @@ call_api(produce, [HostsStr, TopicStr, PartitionStr, KVStr]) ->
   Pos = string:chr(KVStr, $:),
   Key = iolist_to_binary(string:left(KVStr, Pos - 1)),
   Value = iolist_to_binary(string:right(KVStr, length(KVStr) - Pos)),
-  {ok, Client} = brod_client:start_link(Hosts, []),
+  Client = brod_cli,
+  {ok, _Pid} = brod_client:start_link(Hosts, Client, []),
   ok = brod:start_producer(Client, Topic, []),
   Res = brod:produce_sync(Client, Topic, Partition, Key, Value),
   brod_client:stop(Client),

--- a/src/brod_int.hrl
+++ b/src/brod_int.hrl
@@ -64,7 +64,6 @@
 
 -define(undef, undefined).
 
--define(DEFAULT_CLIENT_ID, brod).
 -define(GROUP_PROTOCOL_0, <<"brod-consumer-protocol-0">>).
 
 -define(OFFSET_EARLIEST, earliest).

--- a/src/brod_int.hrl
+++ b/src/brod_int.hrl
@@ -54,8 +54,6 @@
 -type topic_assignment()     :: {topic(), [partition_assignment()]}.
 -type member_assignment()    :: {member_id(), [topic_assignment()]}.
 
--define(IS_MEMBER_ID(X), is_binary(X)).
-
 -record(socket, { pid     :: pid()
                 , host    :: string()
                 , port    :: integer()
@@ -63,8 +61,6 @@
                 }).
 
 -define(undef, undefined).
-
--define(GROUP_PROTOCOL_0, <<"brod-consumer-protocol-0">>).
 
 -define(OFFSET_EARLIEST, earliest).
 -define(OFFSET_LATEST, latest).


### PR DESCRIPTION
All public APIs (exposed from brod.erl) call brod_client:start_link/3.
There is no need to keep brod_client:start_link/2 any more.
Also added few TODOs to remind us to clean up more when the deprecated APIs brod:start_link_client/_ are removed
