### PR TITLE
Prepare brod for use in Kred

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.1.7
+PROJECT_VERSION = 2.1.9
 
 DEPS = supervisor3 kafka_protocol
 
@@ -26,4 +26,3 @@ t: eunit ct
 	./scripts/cover-summary.escript eunit.coverdata ct.coverdata
 
 ESCRIPT_FILE = scripts/$(PROJECT)
-

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.1.8"},
+  {vsn,"2.1.9"},
   {registered,[]},
   {applications,[kernel,stdlib,supervisor3,kafka_protocol]},
   {env,[]},
@@ -12,4 +12,3 @@
   {links, [{"Github", "https://github.com/klarna/brod"}]},
   {build_tools, ["make", "rebar3"]},
   {files, ["src", "include", "scripts", "docker", "rebar.config", "rebar.lock", "README.md","LICENSE", "NOTICE", "AUTHORS", "Makefile", "erlang.mk", "sys.config.example"]}]}.
-

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -89,6 +89,23 @@
 
 -deprecated([{start_link_client, '_', next_version}]).
 
+-export_type([ brod_call_ref/0
+             , brod_client_id/0
+             , brod_partition_fun/0
+             , client/0
+             , client_config/0
+             , consumer_config/0
+             , consumer_options/0
+             , endpoint/0
+             , group_config/0
+             , group_id/0
+             , kpro_MetadataResponse/0
+             , offset/0
+             , offset_time/0
+             , producer_config/0
+             , topic/0
+             ]).
+
 -include("brod_int.hrl").
 
 %%%_* APIs =====================================================================

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -441,14 +441,14 @@ get_offsets(Hosts, Topic, Partition, TimeOrSemanticOffset, MaxNoOffsets) ->
 
 %% @equiv fetch(Hosts, Topic, Partition, Offset, 1000, 0, 100000)
 -spec fetch([endpoint()], binary(), non_neg_integer(), integer()) ->
-               {ok, [#kafka_message{}]} | {error, any()}.
+               {ok, [#kafka_message{} | ?incomplete_message]} | {error, any()}.
 fetch(Hosts, Topic, Partition, Offset) ->
   fetch(Hosts, Topic, Partition, Offset, 1000, 0, 100000).
 
 %% @doc Fetch a single message set from a specified topic/partition
 -spec fetch([endpoint()], topic(), partition(), offset_time(),
             non_neg_integer(), non_neg_integer(), pos_integer()) ->
-               {ok, [#kafka_message{}]} | {error, any()}.
+               {ok, [#kafka_message{} | ?incomplete_message]} | {error, any()}.
 fetch(Hosts, Topic, Partition, Offset, MaxWaitTime, MinBytes, MaxBytes) ->
   {ok, Pid} = connect_leader(Hosts, Topic, Partition),
   Request = kpro:fetch_request(Topic, Partition, Offset,
@@ -464,7 +464,7 @@ fetch(Hosts, Topic, Partition, Offset, MaxWaitTime, MinBytes, MaxBytes) ->
     true ->
       {error, kpro_ErrorCode:desc(ErrorCode)};
     false ->
-      {ok, Messages}
+      {ok, lists:map(fun brod_utils:kafka_message/1, Messages)}
   end.
 
 %% escript entry point

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -619,7 +619,7 @@ handle_socket_down(#state{ client_id       = ClientId
       NewSockets = lists:keystore(Endpoint, #sock.endpoint, Sockets, NewSocket),
       {ok, State#state{payload_sockets = NewSockets}};
     false ->
-      %% is_process_alive is checked and reconnect is done for metadata
+      %% is_pid_alive is checked and reconnect is done for metadata
       %% socket in maybe_restart_metadata_socket, hence the 'EXIT' message
       %% of old metadata socket pid may end up in this clause, simply ignore
       {ok, State}
@@ -803,7 +803,7 @@ rotate_endpoints(State, Reason) ->
 %% @private Maybe restart the metadata socket pid if it is no longer alive.
 -spec maybe_restart_metadata_socket(#state{}) -> {ok, #state{}}.
 maybe_restart_metadata_socket(#state{meta_sock_pid = MetaSockPid} = State) ->
-  case is_pid(MetaSockPid) andalso is_process_alive(MetaSockPid) of
+  case brod_utils:is_pid_alive(MetaSockPid) of
     true ->
       {ok, State};
     false -> % can happen when metadata connection closed

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -225,8 +225,7 @@ handle_info({'DOWN', _MonitorRef, process, Pid, _Reason},
             #state{socket_pid = Pid} = State) ->
   ok = maybe_send_init_socket(State),
   State1 = State#state{socket_pid = ?undef},
-  NewState = reset_buffer(State1),
-  {noreply, NewState};
+  {noreply, State1};
 handle_info(Info, State) ->
   error_logger:warning_msg("~p ~p got unexpected info: ~p",
                           [?MODULE, self(), Info]),

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -365,16 +365,7 @@ err_op(_)                              -> restart.
 map_messages([?incomplete_message]) ->
   [?incomplete_message];
 map_messages(Messages) ->
-  F = fun(#kpro_Message{} = M) ->
-            #kafka_message{ offset     = M#kpro_Message.offset
-                          , magic_byte = M#kpro_Message.magicByte
-                          , attributes = M#kpro_Message.attributes
-                          , key        = M#kpro_Message.key
-                          , value      = M#kpro_Message.value
-                          , crc        = M#kpro_Message.crc
-                          }
-      end,
-  [F(M) || M <- Messages, M =/= ?incomplete_message].
+  [brod_utils:kafka_message(M) || M <- Messages, M =/= ?incomplete_message].
 
 handle_fetch_error(#kafka_fetch_error{error_code = ErrorCode} = Error,
                    #state{ topic      = Topic

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -195,8 +195,7 @@ init({ClientPid, Topic, Partition, Config}) ->
              }}.
 
 handle_info(?INIT_SOCKET, #state{subscriber = Subscriber} = State0) ->
-  case is_pid(Subscriber) andalso
-       is_process_alive(Subscriber) andalso
+  case brod_utils:is_pid_alive(Subscriber) andalso
        maybe_init_socket(State0) of
     false ->
       %% subscriber not alive
@@ -233,9 +232,8 @@ handle_info(Info, State) ->
 
 handle_call({subscribe, Pid, Options}, _From,
             #state{subscriber = Subscriber} = State0) ->
-  case Subscriber =:= ?undef           orelse %% no old subscriber
-      not is_process_alive(Subscriber) orelse %% old subscirber died
-      Subscriber =:= Pid of                   %% re-subscribe
+  case (not brod_utils:is_pid_alive(Subscriber)) %% old subscriber died
+    orelse Subscriber =:= Pid of                 %% re-subscribe
     true ->
       case maybe_init_socket(State0) of
         {ok, State} ->
@@ -597,7 +595,7 @@ maybe_init_socket(State) ->
 maybe_send_init_socket(#state{subscriber = Subscriber}) ->
   Timeout = ?SOCKET_RETRY_DELAY_MS,
   %% re-init payload socket only when subscriber is alive
-  is_pid(Subscriber) andalso is_process_alive(Subscriber) andalso
+  brod_utils:is_pid_alive(Subscriber) andalso
     erlang:send_after(Timeout, self(), ?INIT_SOCKET),
   ok.
 

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -295,7 +295,7 @@ handle_fetch_response(_Response, _CorrId,
   {noreply, State};
 handle_fetch_response(_Response, CorrId1,
                       #state{ last_corr_id = CorrId2
-                            } = State) when CorrId1 < CorrId2 ->
+                            } = State) when CorrId1 =/= CorrId2 ->
   {noreply, State};
 handle_fetch_response(#kpro_FetchResponse{ fetchResponseTopic_L = [TopicData]
                                          }, CorrId, State) ->

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -388,11 +388,8 @@ discover_coordinator(#state{ client      = Client
                            , groupId     = GroupId
                            } = State) ->
   {Host, Port} = ?ESCALATE(brod_client:get_group_coordinator(Client, GroupId)),
-  HasConnectionToCoordinator =
-    case Coordinator =:= {Host, Port} of
-      true  -> is_pid(SockPid) andalso is_process_alive(SockPid);
-      false -> false
-    end,
+  HasConnectionToCoordinator = Coordinator =:= {Host, Port}
+    andalso brod_utils:is_pid_alive(SockPid),
   case HasConnectionToCoordinator of
     true ->
       {ok, State};

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -457,7 +457,7 @@ subscribe_partition(Client, Consumer) ->
            , begin_offset    = BeginOffset0
            , acked_offset    = AckedOffset
            } = Consumer,
-  case is_pid(Pid) andalso is_process_alive(Pid) of
+  case brod_utils:is_pid_alive(Pid) of
     true ->
       Consumer;
     false ->

--- a/src/brod_sock.erl
+++ b/src/brod_sock.erl
@@ -165,10 +165,9 @@ init(Parent, Host, Port, ClientId, Debug0) ->
 
 system_call(Pid, Request) ->
   Mref = erlang:monitor(process, Pid),
-  Ref = erlang:make_ref(),
-  erlang:send(Pid, {system, {self(), Ref}, Request}),
+  erlang:send(Pid, {system, {self(), Mref}, Request}),
   receive
-    {Ref, Reply} ->
+    {Mref, Reply} ->
       erlang:demonitor(Mref, [flush]),
       Reply;
     {'DOWN', Mref, _, _, Reason} ->
@@ -177,10 +176,9 @@ system_call(Pid, Request) ->
 
 call(Pid, Request) ->
   Mref = erlang:monitor(process, Pid),
-  Ref = erlang:make_ref(),
-  erlang:send(Pid, {{self(), Ref}, Request}),
+  erlang:send(Pid, {{self(), Mref}, Request}),
   receive
-    {Ref, Reply} ->
+    {Mref, Reply} ->
       erlang:demonitor(Mref, [flush]),
       Reply;
     {'DOWN', Mref, _, _, Reason} ->

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -262,7 +262,7 @@ subscribe_partition(Client, Topic, Consumer) ->
            , consumer_pid = Pid
            , acked_offset = AckedOffset
            } = Consumer,
-  case is_pid(Pid) andalso is_process_alive(Pid) of
+  case brod_utils:is_pid_alive(Pid) of
     true ->
       %% already subscribed
       Consumer;

--- a/test/brod_demo_group_subscriber_koc.erl
+++ b/test/brod_demo_group_subscriber_koc.erl
@@ -101,11 +101,11 @@ spawn_consumers(ClientId, Topic, ConsumerCount) ->
   lists:foreach(
     fun(_I) ->
       {ok, _Subscriber} =
-        brod:start_link_group_subscriber(ClientId, GroupId, [Topic],
-                                         GroupConfig,
-                                         _ConsumerConfig  = [{begin_offset, -2}],
-                                         _CallbackModule  = ?MODULE,
-                                         _CallbackInitArg = [])
+        brod:start_link_group_subscriber(
+          ClientId, GroupId, [Topic], GroupConfig,
+          _ConsumerConfig  = [{begin_offset, -2}],
+          _CallbackModule  = ?MODULE,
+          _CallbackInitArg = [])
     end, lists:seq(1, ConsumerCount)).
 
 spawn_producers(_ClientId, _Topic, _DelaySeconds, []) -> ok;


### PR DESCRIPTION
There are a number of fixes in this PR including coding standard violations, some random bugs, minor refactorings and a fix for `brod:fetch/7` to adhere to its type spec.
