### PR TITLE
support produce kv-list batch as message set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_VERSION = 2.2.0
 DEPS = supervisor3 kafka_protocol
 
 dep_supervisor_commit = 1.1.2
-dep_kafka_protocol_commit = produce-nested-kv-list
+dep_kafka_protocol_commit = 0.6.0
 
 TEST_DEPS = meck proper
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.1.9
+PROJECT_VERSION = 2.2.0
 
 DEPS = supervisor3 kafka_protocol
 
-dep_supervisor_commit = 1.1.1
-dep_kafka_protocol_commit = 0.4.0
+dep_supervisor_commit = 1.1.2
+dep_kafka_protocol_commit = produce-nested-kv-list
 
 TEST_DEPS = meck proper
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Put below configs to client config in sys.config or app env:
       erlang:exit(timeout)
     end.
 
+
 ### Synchronized produce request
 
 Block calling process until Kafka confirmed the message:
@@ -123,6 +124,24 @@ or the same in one call:
                        {ok, crypto:rand_uniform(0, PartitionsCount)}
                    end,
     {ok, CallRef} = brod:produce(Client, Topic, PartitionFun, Key, Value).
+
+
+### Produce a batch of (nested) Key-Value list
+
+    %% The top-level key is used for partitioning
+    %% and nested keys are discarded.
+    %% Nested messages are serialized into a message set to the same partition.
+    brod:produce(_Client    = brod_client_1,
+                 _Topic     = <<"brod-test-topic-1">>,
+                 _Partition = MyPartitionerFun
+                 _Key       = KeyUsedForPartitioning
+                 _Value     = [ {<<"k1", <<"v1">>}
+                              , {<<"k2", <<"v2">>}
+                              , { _KeyDiscarded = <<>>
+                                , [ {<<"k3">>, <<"v3">>}
+                                  , {<<"k4">>, <<"v4">>}
+                                  ]}
+                              ]).
 
 ### Handle acks from kafka
 

--- a/include/brod.hrl
+++ b/include/brod.hrl
@@ -17,10 +17,13 @@
 -ifndef(__BROD_HRL).
 -define(__BROD_HRL, true).
 
--type kafka_topic()               :: binary().
--type kafka_partition()           :: non_neg_integer().
--type kafka_offset()              :: integer().
--type kafka_error_code()          :: atom() | integer().
+-type kafka_key()                 :: kpro:key().
+-type kafka_value()               :: kpro:value().
+-type kafka_kv_list()             :: kpro:kv_list().
+-type kafka_topic()               :: kpro:topic().
+-type kafka_partition()           :: kpro:partition().
+-type kafka_offset()              :: kpro:offset().
+-type kafka_error_code()          :: kpro:error_code().
 -type kafka_group_id()            :: binary().
 -type kafka_group_member_id()     :: binary().
 -type kafka_group_generation_id() :: non_neg_integer().

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.1.9"},
+  {vsn,"2.2.0"},
   {registered,[]},
   {applications,[kernel,stdlib,supervisor3,kafka_protocol]},
   {env,[]},

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -307,9 +307,9 @@ produce_sync(Pid, Key, Value) ->
   end.
 
 %% @doc Sync version of produce/5
-%% This function will not reutnr until a response is received from kafka,
+%% This function will not return until a response is received from kafka,
 %% however if producer is started with required_acks set to 0, this function
-%% will return onece the messages is buffered in the producer process.
+%% will return once the messages are buffered in the producer process.
 %% @end
 -spec produce_sync(client(), topic(), partition() | brod_partition_fun(),
                    key(), value()) -> ok | {error, any()}.

--- a/src/brod_int.hrl
+++ b/src/brod_int.hrl
@@ -32,13 +32,19 @@
 -type portnum()          :: pos_integer().
 -type endpoint()         :: {hostname(), portnum()}.
 -type leader_id()        :: non_neg_integer().
--type kafka_kv()         :: {binary(), binary()}.
 -type client_config()    :: brod_client_config().
 -type producer_config()  :: brod_producer_config().
 -type consumer_config()  :: brod_consumer_config().
 -type consumer_options() :: [{consumer_option(), integer()}].
 -type client()           :: brod_client_id() | pid().
 -type required_acks()    :: -1..1.
+-type key()              :: kafka_key().
+-type value()            :: kafka_value().
+-type kv_list()          :: kafka_kv_list().
+-type offset()           :: kafka_offset().
+-type partition()        :: kafka_partition().
+-type topic()            :: kafka_topic().
+-type corr_id()          :: kpro:corr_id().
 
 %% consumer groups
 -type group_id()             :: kafka_group_id().

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -139,7 +139,7 @@ start_link(ClientPid, Topic, Partition, Config) ->
 %% message after the produce request has been acked by configured number of
 %% replicas in kafka cluster.
 %% @end
--spec produce(pid(), binary(), binary()) ->
+-spec produce(pid(), key(), value()) ->
         {ok, brod_call_ref()} | {error, any()}.
 produce(Pid, Key, Value) ->
   CallRef = #brod_call_ref{ caller = self()

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -39,6 +39,7 @@
         , t_producer_topic_not_found/1
         , t_producer_partition_not_found/1
         , t_produce_partitioner/1
+        , t_produce_batch/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -234,6 +235,29 @@ t_produce_partitioner(Config) when is_list(Config) ->
   ReceiveFun(0, K1, V1),
   ok = brod:produce_sync(Client, ?TOPIC, PartFun, K2, V2),
   ReceiveFun(1, K2, V2).
+
+t_produce_batch(Config) when is_list(Config) ->
+  Client = ?config(client),
+  Partition = 0,
+  {K1, V1} = make_unique_kv(),
+  {K2, V2} = make_unique_kv(),
+  {K3, V3} = make_unique_kv(),
+  Batch = [{K1, V1}, {K2, V2}, {<<>>, [{K3, V3}]}],
+  ok = brod:produce_sync(Client, ?TOPIC, Partition, undefined, Batch),
+  ReceiveFun =
+    fun(ExpectedK, ExpectedV) ->
+      receive
+        {_, K, V} ->
+          ?assertEqual(ExpectedK, K),
+          ?assertEqual(ExpectedV, V)
+        after 5000 ->
+          ct:fail({?MODULE, ?LINE, timeout, ExpectedK, ExpectedV})
+      end
+    end,
+  ReceiveFun(K1, V1),
+  ReceiveFun(K2, V2),
+  ReceiveFun(K3, V3).
+
 
 %%%_* Help functions ===========================================================
 

--- a/test/brod_producer_buffer_SUITE.erl
+++ b/test/brod_producer_buffer_SUITE.erl
@@ -66,10 +66,12 @@ all() -> [F || {F, _A} <- module_info(exports),
 %%%_* Test functions ===========================================================
 
 t_no_ack(Config) when is_list(Config) ->
-  ?assert(proper:quickcheck(prop_no_ack_run(), 1000)).
+  Opts = [{numtests, 1000}, {to_file, user}],
+  ?assert(proper:quickcheck(prop_no_ack_run(), Opts)).
 
 t_random_latency_ack(Config) when is_list(Config) ->
-  ?assert(proper:quickcheck(prop_random_latency_ack_run(), 500)).
+  Opts = [{numtests, 500}, {to_file, user}],
+  ?assert(proper:quickcheck(prop_random_latency_ack_run(), Opts)).
 
 t_nack(Config) when is_list(Config) ->
   SendFun =


### PR DESCRIPTION
For messages that are already batched on caller side, there is no need to break down and re-assemble.
Also easier to achieve better compression ratio if compression is enable.
