### PR TITLE
brod_sock: if requiredAcks = 0 don't store the request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.1.9
+PROJECT_VERSION = 2.1.10
 
 DEPS = supervisor3 kafka_protocol
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.1.9"},
+  {vsn,"2.1.10"},
   {registered,[]},
   {applications,[kernel,stdlib,supervisor3,kafka_protocol]},
   {env,[]},

--- a/src/brod_kafka_requests.erl
+++ b/src/brod_kafka_requests.erl
@@ -34,6 +34,7 @@
         , del/2
         , get_caller/2
         , get_corr_id/1
+	, increment_corr_id/1
         ]).
 
 -export_type([requests/0]).
@@ -87,6 +88,13 @@ get_caller(#requests{sent = Sent}, CorrId) ->
 -spec get_corr_id(requests()) -> corr_id().
 get_corr_id(#requests{ corr_id = CorrId }) ->
   CorrId.
+
+%% @doc Fetch and increment the correlation ID
+%% This is used if we don't want a response from the broker
+%% @end
+-spec increment_corr_id(requests()) -> {corr_id(), requests()}.
+increment_corr_id(#requests{corr_id = CorrId} = Requests) ->
+  {CorrId, Requests#requests{ corr_id = kpro:next_corr_id(CorrId) }}.
 
 %%%_* Internal function ========================================================
 

--- a/src/brod_sock.erl
+++ b/src/brod_sock.erl
@@ -225,7 +225,12 @@ handle_msg({From, {send, Request}},
                  , requests  = Requests
                  } = State, Debug) ->
   {Caller, _Ref} = From,
-  {CorrId, NewRequests} = brod_kafka_requests:add(Requests, Caller),
+  {CorrId, NewRequests} = case Request of
+      #kpro_ProduceRequest{requiredAcks = 0} ->
+        brod_kafka_requests:increment_corr_id(Requests);
+      _ ->
+        brod_kafka_requests:add(Requests, Caller)
+  end,
   RequestBin = kpro:encode_request(ClientId, CorrId, Request),
   ok = gen_tcp:send(Sock, RequestBin),
   reply(From, {ok, CorrId}),


### PR DESCRIPTION
Hi,
First off, thanks for all your work on the library. We're investigating using kafka for logging at my job and while trying to set that up I've noticed a few issues. I realize that since we're looking for high-throughput logging our goals might be slightly different from yours, but hopefully most of our changes will be useful for everyone using the library.

I noticed that the brod_sock state will grow indefinitely if requiredAcks is set to 0 because we keep them while waiting for a response. I presume we still need to increase the corr_id so I've added a new function to do that without storing the request.
