### PR TITLE
Receive one reference

### DIFF
--- a/src/brod_sock.erl
+++ b/src/brod_sock.erl
@@ -165,10 +165,9 @@ init(Parent, Host, Port, ClientId, Debug0) ->
 
 system_call(Pid, Request) ->
   Mref = erlang:monitor(process, Pid),
-  Ref = erlang:make_ref(),
-  erlang:send(Pid, {system, {self(), Ref}, Request}),
+  erlang:send(Pid, {system, {self(), Mref}, Request}),
   receive
-    {Ref, Reply} ->
+    {Mref, Reply} ->
       erlang:demonitor(Mref, [flush]),
       Reply;
     {'DOWN', Mref, _, _, Reason} ->
@@ -177,10 +176,9 @@ system_call(Pid, Request) ->
 
 call(Pid, Request) ->
   Mref = erlang:monitor(process, Pid),
-  Ref = erlang:make_ref(),
-  erlang:send(Pid, {{self(), Ref}, Request}),
+  erlang:send(Pid, {{self(), Mref}, Request}),
   receive
-    {Ref, Reply} ->
+    {Mref, Reply} ->
       erlang:demonitor(Mref, [flush]),
       Reply;
     {'DOWN', Mref, _, _, Reason} ->


### PR DESCRIPTION
This fixes another source of slowness we identified while trying to use the library for logging through kafka. We have a process per log target that does some formatting and sends the produce request on to brod, but we found that when the process was receiving a large number of messages it was causing huge slowdowns when the process got behind while processing its message queue. These patches fix the problem in the two places I noticed it.
