### PR TITLE
Fix SSL on Consumer Group

### DIFF
--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -235,7 +235,7 @@ get_partitions_count(Client, Topic) when is_pid(Client) ->
 
 %% @doc Get the endpoint of the group coordinator broker.
 -spec get_group_coordinator(client(), group_id()) ->
-        {ok, endpoint()} | {error, any()}.
+        {ok, {endpoint(), client_config()}} | {error, any()}.
 get_group_coordinator(Client, GroupId) ->
   safe_gen_call(Client, {get_group_coordinator, GroupId}, infinity).
 
@@ -351,7 +351,7 @@ handle_call({get_group_coordinator, GroupId}, _From, State) ->
                                          }} ->
         case kpro_ErrorCode:is_error(EC) of
           true  -> {error, EC}; %% OBS: {error, EC} is used by group coordinator
-          false -> {ok, {binary_to_list(Host), Port}}
+          false -> {ok, {{binary_to_list(Host), Port},Config}}
         end;
       {error, Reason} ->
         {error, Reason}

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -387,7 +387,8 @@ discover_coordinator(#state{ client      = Client
                            , sock_pid    = SockPid
                            , groupId     = GroupId
                            } = State) ->
-  {Host, Port} = ?ESCALATE(brod_client:get_group_coordinator(Client, GroupId)),
+  {{Host, Port}, Config} =
+    ?ESCALATE(brod_client:get_group_coordinator(Client, GroupId)),
   HasConnectionToCoordinator = Coordinator =:= {Host, Port}
     andalso brod_utils:is_pid_alive(SockPid),
   case HasConnectionToCoordinator of
@@ -398,7 +399,7 @@ discover_coordinator(#state{ client      = Client
       _ = brod_sock:stop(SockPid),
       ClientId = make_group_connection_client_id(),
       NewSockPid =
-        ?ESCALATE(brod_sock:start_link(self(), Host, Port, ClientId, [])),
+        ?ESCALATE(brod_sock:start_link(self(), Host, Port, ClientId, Config)),
       log(State, info, "connected to group coordinator ~s:~p",
           [Host, Port]),
       NewState =


### PR DESCRIPTION
Hi,

I've done some testing connecting a Brod service with a Kafka with an SSL listener (no plaintext listener). Producing messages works perfectly but the consumer group is failing.

The problem is that the socket opened by the brod_group _coordinator is not using the SSL configuration defined in the client.
