### PR TITLE
2.2 dev --> master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,14 @@ script:
   - make escript
   - scripts/cli-produce-test.sh
   - make distclean
+  - echo "verifying rebar compilation"
   - rebar get-deps
   - rebar compile
+  - rm rebar.lock # delete rebar.lock so it gets re-created, expecting no diff
   - make distclean
+  - echo "verifying rebar3 compilation"
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3
   - ./rebar3 compile
+  - DIFF=$(git diff rebar.lock); if [ -n "$DIFF" ]; then echo 'rebar.lock discrepancy'; exit 1; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ notifications:
   email: false
 
 otp_release:
-  - 18.1
-  - 17.4
-  - R16B03-1
+  - 18.2.1
+  - 17.5
+  - R16B03
 
 script:
   - make test-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,10 @@ script:
   - set -e
   - make vsn-check
   - scripts/line-width-check.sh
-  - make test-env
   - make deps
-  - make t
+  - make app
   - make xref
   - make edoc
-  - make escript
-  - scripts/cli-produce-test.sh
   - make distclean
   - echo "verifying rebar compilation"
   - rebar get-deps
@@ -41,4 +38,9 @@ script:
   - chmod +x rebar3
   - ./rebar3 compile
   - DIFF=$(git diff rebar.lock); if [ -n "$DIFF" ]; then echo 'rebar.lock discrepancy'; exit 1; fi;
+  - make distclean
+  - make escript
+  - make test-env
+  - scripts/cli-produce-test.sh
+  - make t
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ otp_release:
   - 17.5
 
 script:
+  - set -e
   - make vsn-check
+  - scripts/line-width-check.sh
   - make test-env
   - make deps
   - make t

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_VERSION = 2.2.0
 DEPS = supervisor3 kafka_protocol
 
 dep_supervisor_commit = 1.1.2
-dep_kafka_protocol_commit = produce-nested-kv-list
+dep_kafka_protocol_commit = 0.6.0
 
 TEST_DEPS = meck proper
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_VERSION = 2.2.0
 DEPS = supervisor3 kafka_protocol
 
 dep_supervisor3_commit = 1.1.2
-dep_kafka_protocol_commit = 0.6.0
+dep_kafka_protocol_commit = 0.7.0
 
 TEST_DEPS = meck proper
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.1.9
+PROJECT_VERSION = 2.2.0
 
 DEPS = supervisor3 kafka_protocol
 
-dep_supervisor_commit = 1.1.1
-dep_kafka_protocol_commit = 0.4.0
+dep_supervisor_commit = 1.1.2
+dep_kafka_protocol_commit = produce-nested-kv-list
 
 TEST_DEPS = meck proper
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Put below configs to client config in sys.config or app env:
       erlang:exit(timeout)
     end.
 
+
 ### Synchronized produce request
 
 Block calling process until Kafka confirmed the message:
@@ -123,6 +124,24 @@ or the same in one call:
                        {ok, crypto:rand_uniform(0, PartitionsCount)}
                    end,
     {ok, CallRef} = brod:produce(Client, Topic, PartitionFun, Key, Value).
+
+
+### Produce a batch of (nested) Key-Value list
+
+    %% The top-level key is used for partitioning
+    %% and nested keys are discarded.
+    %% Nested messages are serialized into a message set to the same partition.
+    brod:produce(_Client    = brod_client_1,
+                 _Topic     = <<"brod-test-topic-1">>,
+                 _Partition = MyPartitionerFun
+                 _Key       = KeyUsedForPartitioning
+                 _Value     = [ {<<"k1", <<"v1">>}
+                              , {<<"k2", <<"v2">>}
+                              , { _KeyDiscarded = <<>>
+                                , [ {<<"k3">>, <<"v3">>}
+                                  , {<<"k4">>, <<"v4">>}
+                                  ]}
+                              ]).
 
 ### Handle acks from kafka
 

--- a/erlang.mk
+++ b/erlang.mk
@@ -3467,6 +3467,14 @@ pkg_smother_fetch = git
 pkg_smother_repo = https://github.com/ramsay-t/Smother
 pkg_smother_commit = master
 
+PACKAGES += snappyer
+pkg_snappyer_name = snappyer
+pkg_snappyer_description = Snappy as nif for Erlang
+pkg_snappyer_homepage = https://github.com/zmstone/snappyer
+pkg_snappyer_fetch = git
+pkg_snappyer_repo = https://github.com/zmstone/snappyer.git
+pkg_snappyer_commit = master
+
 PACKAGES += social
 pkg_social_name = social
 pkg_social_description = Cowboy handler for social login via OAuth2 providers

--- a/include/brod.hrl
+++ b/include/brod.hrl
@@ -17,10 +17,13 @@
 -ifndef(__BROD_HRL).
 -define(__BROD_HRL, true).
 
--type kafka_topic()               :: binary().
--type kafka_partition()           :: non_neg_integer().
--type kafka_offset()              :: integer().
--type kafka_error_code()          :: atom() | integer().
+-type kafka_key()                 :: kpro:key().
+-type kafka_value()               :: kpro:value().
+-type kafka_kv_list()             :: kpro:kv_list().
+-type kafka_topic()               :: kpro:topic().
+-type kafka_partition()           :: kpro:partition().
+-type kafka_offset()              :: kpro:offset().
+-type kafka_error_code()          :: kpro:error_code().
 -type kafka_group_id()            :: binary().
 -type kafka_group_member_id()     :: binary().
 -type kafka_group_generation_id() :: non_neg_integer().

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [ {supervisor3, "1.1.2"}
-       , {kafka_protocol, "0.6.0"}
+       , {kafka_protocol, "0.7.0"}
        ]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [ {supervisor3, "1.1.1"}
-       , {kafka_protocol, "0.4.0"}
+{deps, [ {supervisor3, "1.1.2"}
+       , {kafka_protocol, "0.6.0"}
        ]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,10 @@
 {"1.1.0",
-[{<<"kafka_protocol">>,{pkg,<<"kafka_protocol">>,<<"0.4.0">>},0},
+[{<<"kafka_protocol">>,{pkg,<<"kafka_protocol">>,<<"0.7.2">>},0},
+ {<<"snappyer">>,{pkg,<<"snappyer">>,<<"1.1.3-1.0.3">>},1},
  {<<"supervisor3">>,{pkg,<<"supervisor3">>,<<"1.1.3">>},0}]}.
 [
 {pkg_hash,[
- {<<"kafka_protocol">>, <<"2510B1696142F6E5DB01E4B12D4E0C7F14B2C7AEF5C2D4ED7B847D485E20E78E">>},
+ {<<"kafka_protocol">>, <<"DB7992C8A18DB373057EE9F88554261B7B946A6894D8CBF9BA7C9D3C48AA24E6">>},
+ {<<"snappyer">>, <<"964F889E9EFAFBC5B4036EFE257BCB2EAD679BC6CAF72544F759EAECA9C0A36C">>},
  {<<"supervisor3">>, <<"96D0553CA94F7998EC515004CAF0419E0BC989907EBCEBCACA1D3E19AF0D52F6">>}]}
 ].

--- a/scripts/line-width-check.sh
+++ b/scripts/line-width-check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+THIS_DIR="$(dirname $(readlink -f $0))"
+count=0
+for file in $THIS_DIR/../src/*.erl; do
+  lines=$(cat $file | awk '{if(length($0) > 80){printf "%d %s\\n", NR, $0;}}')
+  if [ -n "$lines" ]; then
+    echo $file
+    echo -e $lines
+    count=$((count + 1))
+  fi
+done
+exit $count
+

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.1.9"},
+  {vsn,"2.2.0"},
   {registered,[]},
   {applications,[kernel,stdlib,supervisor3,kafka_protocol]},
   {env,[]},

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -307,9 +307,9 @@ produce_sync(Pid, Key, Value) ->
   end.
 
 %% @doc Sync version of produce/5
-%% This function will not reutnr until a response is received from kafka,
+%% This function will not return until a response is received from kafka,
 %% however if producer is started with required_acks set to 0, this function
-%% will return onece the messages is buffered in the producer process.
+%% will return once the messages are buffered in the producer process.
 %% @end
 -spec produce_sync(client(), topic(), partition() | brod_partition_fun(),
                    key(), value()) -> ok | {error, any()}.

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -235,7 +235,7 @@ get_partitions_count(Client, Topic) when is_pid(Client) ->
 
 %% @doc Get the endpoint of the group coordinator broker.
 -spec get_group_coordinator(client(), group_id()) ->
-        {ok, endpoint()} | {error, any()}.
+        {ok, {endpoint(), client_config()}} | {error, any()}.
 get_group_coordinator(Client, GroupId) ->
   safe_gen_call(Client, {get_group_coordinator, GroupId}, infinity).
 
@@ -351,7 +351,7 @@ handle_call({get_group_coordinator, GroupId}, _From, State) ->
                                          }} ->
         case kpro_ErrorCode:is_error(EC) of
           true  -> {error, EC}; %% OBS: {error, EC} is used by group coordinator
-          false -> {ok, {binary_to_list(Host), Port}}
+          false -> {ok, {{binary_to_list(Host), Port},Config}}
         end;
       {error, Reason} ->
         {error, Reason}

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -53,14 +53,16 @@
                              | reset_to_earliest
                              | reset_to_latest.
 
+-type bytes() :: non_neg_integer().
+
 -record(state, { client_pid          :: pid()
                , socket_pid          :: pid()
                , topic               :: binary()
                , partition           :: integer()
                , begin_offset        :: offset_time()
                , max_wait_time       :: integer()
-               , min_bytes           :: integer()
-               , max_bytes           :: integer()
+               , min_bytes           :: bytes()
+               , max_bytes_orig      :: bytes()
                , sleep_timeout       :: integer()
                , prefetch_count      :: integer()
                , last_corr_id        :: corr_id()
@@ -69,6 +71,8 @@
                , pending_acks = []   :: [offset()]
                , is_suspended        :: boolean()
                , offset_reset_policy :: offset_reset_policy()
+               , avg_bytes           :: number()
+               , max_bytes           :: bytes()
                }).
 
 -define(DEFAULT_BEGIN_OFFSET, ?OFFSET_LATEST).
@@ -76,13 +80,14 @@
 -define(DEFAULT_MAX_BYTES, 1048576).  % 1 MB
 -define(DEFAULT_MAX_WAIT_TIME, 10000). % 10 sec
 -define(DEFAULT_SLEEP_TIMEOUT, 1000). % 1 sec
--define(DEFAULT_PREFETCH_COUNT, 1).
+-define(DEFAULT_PREFETCH_COUNT, 10).
 -define(DEFAULT_OFFSET_RESET_POLICY, reset_by_subscriber).
 -define(ERROR_COOLDOWN, 1000).
 -define(SOCKET_RETRY_DELAY_MS, 1000).
 
 -define(SEND_FETCH_REQUEST, send_fetch_request).
 -define(INIT_SOCKET, init_socket).
+-define(DEFAULT_AVG_WINDOW, 5).
 
 %%%_* APIs =====================================================================
 %% @equiv start_link(ClientPid, Topic, Partition, Config, [])
@@ -99,8 +104,6 @@ start_link(ClientPid, Topic, Partition, Config) ->
 %%     Maximum bytes to fetch in a batch of messages
 %%     NOTE: this value might be doubled in each retry when it is not enough
 %%           to fetch even one single message.
-%%     NOTE: in current implementation, the value is not shrinked back to
-%%           original after it has been expanded.
 %%  max_wait_time (optional, default = 10000 ms):
 %%     Max number of seconds allowd for the broker to collect min_bytes of
 %%     messages in fetch response
@@ -176,7 +179,7 @@ init({ClientPid, Topic, Partition, Config}) ->
   MaxBytes = Cfg(max_bytes, ?DEFAULT_MAX_BYTES),
   MaxWaitTime = Cfg(max_wait_time, ?DEFAULT_MAX_WAIT_TIME),
   SleepTimeout = Cfg(sleep_timeout, ?DEFAULT_SLEEP_TIMEOUT),
-  PrefetchCount = Cfg(prefetch_count, ?DEFAULT_PREFETCH_COUNT),
+  PrefetchCount = erlang:max(Cfg(prefetch_count, ?DEFAULT_PREFETCH_COUNT), 1),
   BeginOffset = Cfg(begin_offset, ?DEFAULT_BEGIN_OFFSET),
   OffsetResetPolicy = Cfg(offset_reset_policy, ?DEFAULT_OFFSET_RESET_POLICY),
   ok = brod_client:register_consumer(ClientPid, Topic, Partition),
@@ -186,12 +189,14 @@ init({ClientPid, Topic, Partition, Config}) ->
              , begin_offset        = BeginOffset
              , max_wait_time       = MaxWaitTime
              , min_bytes           = MinBytes
-             , max_bytes           = MaxBytes
+             , max_bytes_orig      = MaxBytes
              , sleep_timeout       = SleepTimeout
              , prefetch_count      = PrefetchCount
              , socket_pid          = ?undef
              , is_suspended        = false
              , offset_reset_policy = OffsetResetPolicy
+             , avg_bytes           = 0
+             , max_bytes           = MaxBytes
              }}.
 
 handle_info(?INIT_SOCKET, #state{subscriber = Subscriber} = State0) ->
@@ -328,13 +333,12 @@ handle_message_set(#kafka_message_set{messages = []}, State0) ->
   State = maybe_delay_fetch_request(State0),
   {noreply, State};
 handle_message_set(#kafka_message_set{messages = [?incomplete_message]},
-                   #state{max_bytes = MaxBytes} = State0) ->
+                   #state{ max_bytes = MaxBytes} = State0) ->
+  %% max_bytes is too small to fetch ONE complete message, double it.
   NewMaxBytes = MaxBytes * 2,
   NewMaxBytes >= (1 bsl 31) andalso
       erlang:error({max_bytes_overflow,
                    <<"perhaps message corruption in broker?">>}),
-  error_logger:warning_msg("~p ~p max_bytes ~p is too small, trying with ~p",
-                           [?MODULE, self(), MaxBytes, NewMaxBytes]),
   State1 = State0#state{max_bytes = NewMaxBytes},
   State = maybe_send_fetch_request(State1),
   {noreply, State};
@@ -349,8 +353,35 @@ handle_message_set(#kafka_message_set{messages = Messages} = MsgSet,
   State = State0#state{ pending_acks = PendingAcks ++ Offsets
                       , begin_offset = LastOffset + 1
                       },
-  NewState = maybe_send_fetch_request(State),
+  State1 = maybe_shrink_max_bytes(State, MsgSet#kafka_message_set.messages),
+  NewState = maybe_send_fetch_request(State1),
   {noreply, NewState}.
+
+maybe_shrink_max_bytes(#state{ prefetch_count = PrefetchCount
+                             , max_bytes_orig = MaxBytesOrig
+                             , max_bytes      = MaxBytes
+                             , avg_bytes      = AvgBytes
+                             } = State, []) ->
+  %% This is the estimated size of a message set based on the
+  %% average size of the last X messages.
+  EstimatedSetSize = erlang:round(PrefetchCount * AvgBytes),
+  %% respect the original max_bytes config
+  NewMaxBytes = erlang:max(EstimatedSetSize, MaxBytesOrig),
+  %% maybe shrink the max_bytes to send in fetch request to NewMaxBytes
+  State#state{max_bytes = erlang:min(NewMaxBytes, MaxBytes)};
+maybe_shrink_max_bytes(#state{ prefetch_count = PrefetchCount
+                             , avg_bytes      = AvgBytes
+                             } = State,
+                       [#kafka_message{key = Key, value = Value} | Rest]) ->
+  %% kafka adds 26 bytes of overhead (metadata) for each message
+  MsgBytes = bytes(Key) + bytes(Value) + 30,
+  %% See https://en.wikipedia.org/wiki/Moving_average
+  WindowSize = erlang:max(PrefetchCount, ?DEFAULT_AVG_WINDOW),
+  NewAvgBytes = ((WindowSize - 1) * AvgBytes + MsgBytes) / WindowSize,
+  maybe_shrink_max_bytes(State#state{avg_bytes = NewAvgBytes}, Rest).
+
+bytes(?undef)              -> 0;
+bytes(B) when is_binary(B) -> size(B).
 
 err_op(?EC_REQUEST_TIMED_OUT)          -> retry;
 err_op(?EC_UNKNOWN_TOPIC_OR_PARTITION) -> stop;
@@ -505,7 +536,7 @@ update_options(Options, #state{begin_offset = OldBeginOffset} = State) ->
   State1 = State#state
     { begin_offset        = NewBeginOffset
     , min_bytes           = F(min_bytes, State#state.min_bytes)
-    , max_bytes           = F(max_bytes, State#state.max_bytes)
+    , max_bytes_orig      = F(max_bytes, State#state.max_bytes_orig)
     , max_wait_time       = F(max_wait_time, State#state.max_wait_time)
     , sleep_timeout       = F(sleep_timeout, State#state.sleep_timeout)
     , prefetch_count      = F(prefetch_count, State#state.prefetch_count)

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -387,7 +387,8 @@ discover_coordinator(#state{ client      = Client
                            , sock_pid    = SockPid
                            , groupId     = GroupId
                            } = State) ->
-  {Host, Port} = ?ESCALATE(brod_client:get_group_coordinator(Client, GroupId)),
+  {{Host, Port}, Config} =
+    ?ESCALATE(brod_client:get_group_coordinator(Client, GroupId)),
   HasConnectionToCoordinator = Coordinator =:= {Host, Port}
     andalso brod_utils:is_pid_alive(SockPid),
   case HasConnectionToCoordinator of
@@ -398,7 +399,7 @@ discover_coordinator(#state{ client      = Client
       _ = brod_sock:stop(SockPid),
       ClientId = make_group_connection_client_id(),
       NewSockPid =
-        ?ESCALATE(brod_sock:start_link(self(), Host, Port, ClientId, [])),
+        ?ESCALATE(brod_sock:start_link(self(), Host, Port, ClientId, Config)),
       log(State, info, "connected to group coordinator ~s:~p",
           [Host, Port]),
       NewState =

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -116,30 +116,25 @@
                   , acked_offset    :: offset()
                   }).
 
--type cb_fun() :: fun((cb_state()) -> {AckNow :: boolean(), cb_state()}).
-
 -type ack_ref() :: {topic(), partition(), offset()}.
 
 -record(state,
-        { client                :: client()
-        , groupId               :: group_id()
-        , memberId              :: member_id()
-        , generationId          :: integer()
-        , coordinator           :: pid()
-        , consumers = []        :: [#consumer{}]
-        , consumer_config       :: consumer_config()
-        , is_blocked = false    :: boolean()
-        , cb_module             :: module()
-        , cb_state              :: cb_state()
-        , pending_ack = ?undef  :: ?undef | ack_ref()
-        , pending_messages = [] :: [{ack_ref(), cb_fun()}]
+        { client             :: client()
+        , groupId            :: group_id()
+        , memberId           :: member_id()
+        , generationId       :: integer()
+        , coordinator        :: pid()
+        , consumers = []     :: [#consumer{}]
+        , consumer_config    :: consumer_config()
+        , is_blocked = false :: boolean()
+        , cb_module          :: module()
+        , cb_state           :: cb_state()
         }).
 
 %% delay 2 seconds retry the failed subscription to partiton consumer process
 -define(RESUBSCRIBE_DELAY, 2000).
 
 -define(LO_CMD_SUBSCRIBE_PARTITIONS, '$subscribe_partitions').
--define(LO_CMD_PROCESS_MESSAGE, '$process_message').
 
 %%%_* APIs =====================================================================
 
@@ -244,30 +239,8 @@ handle_info({_ConsumerPid,
              #kafka_message_set{ topic     = Topic
                                , partition = Partition
                                , messages  = Messages
-                               }},
-            #state{ cb_module        = CbModule
-                  , pending_messages = Pendings
-                  } = State) ->
-  MapFun =
-    fun(#kafka_message{offset = Offset} = Msg) ->
-      AckRef = {Topic, Partition, Offset},
-      CbFun =
-        fun(CbState) ->
-          case CbModule:handle_message(Topic, Partition, Msg, CbState) of
-            {ok, NewCbState} ->
-              {_AckNow = false, NewCbState};
-            {ok, ack, NewCbState} ->
-              {_AckNow = true, NewCbState};
-            Unknown ->
-              erlang:error({bad_return_value,
-                           {CbModule, handle_message, Unknown}})
-          end
-        end,
-      {AckRef, CbFun}
-    end,
-  NewPendings = Pendings ++ lists:map(MapFun, Messages),
-  NewState = State#state{pending_messages = NewPendings},
-  _ = send_lo_cmd(?LO_CMD_PROCESS_MESSAGE),
+                               }}, State) ->
+  NewState = handle_messages(Topic, Partition, Messages, State),
   {noreply, NewState};
 handle_info({'DOWN', _Mref, process, Pid, Reason},
             #state{consumers = Consumers} = State) ->
@@ -283,9 +256,6 @@ handle_info({'DOWN', _Mref, process, Pid, Reason},
     false ->
       {noreply, State}
   end;
-handle_info(?LO_CMD_PROCESS_MESSAGE, State) ->
-  {ok, NewState} = maybe_process_message(State),
-  {noreply, NewState};
 handle_info(?LO_CMD_SUBSCRIBE_PARTITIONS, State) ->
   NewState =
     case State#state.is_blocked of
@@ -333,15 +303,13 @@ handle_call(unsubscribe_all_partitions, _From,
     end, Consumers),
   {reply, ok, State#state{ consumers        = []
                          , is_blocked       = true
-                         , pending_ack      = ?undef
-                         , pending_messages = []
                          }};
 handle_call(Call, _From, State) ->
   {reply, {error, {unknown_call, Call}}, State}.
 
 handle_cast({ack, Topic, Partition, Offset}, State) ->
   AckRef = {Topic, Partition, Offset},
-  {ok, NewState} = handle_ack(AckRef, State),
+  NewState = handle_ack(AckRef, State),
   {noreply, NewState};
 handle_cast(commit_offsets, State) ->
   ok = brod_group_coordinator:commit_offsets(State#state.coordinator),
@@ -389,55 +357,51 @@ terminate(_Reason, #state{}) ->
 
 %%%_* Internal Functions =======================================================
 
--spec maybe_process_message(#state{}) -> {ok, #state{}}.
-maybe_process_message(#state{ pending_ack      = ?undef
-                            , pending_messages = [{AckRef, F} | Rest]
-                            , cb_state         = CbState
-                            } = State) ->
-  %% process new message only when there is no pending ack
-  {AckNow, NewCbState} = F(CbState),
+handle_messages(_Topic, _Partition, [], State) ->
+  State;
+handle_messages(Topic, Partition, [Msg | Rest], State) ->
+  #kafka_message{offset = Offset} = Msg,
+  #state{cb_module = CbModule, cb_state = CbState} = State,
+  AckRef = {Topic, Partition, Offset},
+  {AckNow, NewCbState} =
+    case CbModule:handle_message(Topic, Partition, Msg, CbState) of
+      {ok, NewCbState_} ->
+        {true, NewCbState_};
+      {ok, ack, NewCbState_} ->
+        {false, NewCbState_};
+      Unknown ->
+        erlang:error({bad_return_value,
+                     {CbModule, handle_message, Unknown}})
+    end,
+  State1 = State#state{cb_state = NewCbState},
   NewState =
-    State#state{ pending_ack      = AckRef
-               , pending_messages = Rest
-               , cb_state         = NewCbState
-               },
-  case AckNow of
-    true  -> handle_ack(AckRef, NewState);
-    false -> {ok, NewState}
-  end;
-maybe_process_message(State) ->
-  {ok, State}.
+    case AckNow of
+      true  -> handle_ack(AckRef, State1);
+      false -> State1
+    end,
+  handle_messages(Topic, Partition, Rest, NewState).
 
--spec handle_ack(ack_ref(), #state{}) -> {ok, #state{}}.
-handle_ack(AckRef, #state{ pending_ack      = AckRef
-                         , pending_messages = Messages
-                         , generationId     = GenerationId
-                         , consumers        = Consumers
-                         , coordinator      = Coordinator
-                         } = State0) ->
+-spec handle_ack(ack_ref(), #state{}) -> #state{}.
+handle_ack(AckRef, #state{ generationId = GenerationId
+                         , consumers    = Consumers
+                         , coordinator  = Coordinator
+                         } = State) ->
   {Topic, Partition, Offset} = AckRef,
-  State1 =
-    case lists:keyfind({Topic, Partition},
-                       #consumer.topic_partition, Consumers) of
-      #consumer{consumer_pid = ConsumerPid} = Consumer ->
-        ok = brod:consume_ack(ConsumerPid, Offset),
-        ok = brod_group_coordinator:ack(Coordinator, GenerationId,
-                                        Topic, Partition, Offset),
-        NewConsumer = Consumer#consumer{acked_offset = Offset},
-        NewConsumers = lists:keyreplace({Topic, Partition},
-                                        #consumer.topic_partition,
-                                        Consumers, NewConsumer),
-      State0#state{consumers = NewConsumers};
+  case lists:keyfind({Topic, Partition},
+                     #consumer.topic_partition, Consumers) of
+    #consumer{consumer_pid = ConsumerPid} = Consumer ->
+      ok = brod:consume_ack(ConsumerPid, Offset),
+      ok = brod_group_coordinator:ack(Coordinator, GenerationId,
+                                      Topic, Partition, Offset),
+      NewConsumer = Consumer#consumer{acked_offset = Offset},
+      NewConsumers = lists:keyreplace({Topic, Partition},
+                                      #consumer.topic_partition,
+                                      Consumers, NewConsumer),
+      State#state{consumers = NewConsumers};
     false ->
       %% stale ack, ignore.
-      State0
-    end,
-  Messages =/= [] andalso send_lo_cmd(?LO_CMD_PROCESS_MESSAGE),
-  State = State1#state{pending_ack = ?undef},
-  {ok, State};
-handle_ack(_AckRef, State) ->
-  %% stale ack, ignore.
-  {ok, State}.
+      State
+  end.
 
 send_lo_cmd(CMD) -> send_lo_cmd(CMD, 0).
 

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -74,11 +74,11 @@
 %%   It should call brod_group_subscriber:ack/4 to acknowledge later.
 %%
 %% {ok, ack, NewCallbackState}
-%%   The subscriber has completed processing the message
+%%   The subscriber has completed processing the message.
 %%
-%% NOTE: While this callback function is being evaluated, the fetch-ahead
-%%       partition-consumers are fetching more messages behind the scene
-%%       unless prefetch_count is set to 0 in consumer config.
+%% While this callback function is being evaluated, the fetch-ahead
+%% partition-consumers are fetching more messages behind the scene
+%% unless prefetch_count is set to 0 in consumer config.
 %%
 -callback handle_message(topic(), partition(), #kafka_message{}, cb_state()) ->
             {ok, cb_state()} | {ok, ack, cb_state()}.
@@ -177,7 +177,12 @@ stop(Pid) ->
       ok
   end.
 
-%% @doc Acknowledge a message.
+%% @doc Acknowledge an offset.
+%% The subscriber may ack a later (greater) offset which will be considered
+%% as multi-acking the earlier (smaller) offsets. This also means that
+%% disordered acks may overwrite offset commits and lead to unnecessary
+%% message re-delivery in case of restart.
+%% @end
 -spec ack(pid(), topic(), partition(), offset()) -> ok.
 ack(Pid, Topic, Partition, Offset) ->
   gen_server:cast(Pid, {ack, Topic, Partition, Offset}).

--- a/src/brod_int.hrl
+++ b/src/brod_int.hrl
@@ -32,13 +32,19 @@
 -type portnum()          :: pos_integer().
 -type endpoint()         :: {hostname(), portnum()}.
 -type leader_id()        :: non_neg_integer().
--type kafka_kv()         :: {binary(), binary()}.
 -type client_config()    :: brod_client_config().
 -type producer_config()  :: brod_producer_config().
 -type consumer_config()  :: brod_consumer_config().
 -type consumer_options() :: [{consumer_option(), integer()}].
 -type client()           :: brod_client_id() | pid().
 -type required_acks()    :: -1..1.
+-type key()              :: kafka_key().
+-type value()            :: kafka_value().
+-type kv_list()          :: kafka_kv_list().
+-type offset()           :: kafka_offset().
+-type partition()        :: kafka_partition().
+-type topic()            :: kafka_topic().
+-type corr_id()          :: kpro:corr_id().
 
 %% consumer groups
 -type group_id()             :: kafka_group_id().

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -139,7 +139,7 @@ start_link(ClientPid, Topic, Partition, Config) ->
 %% message after the produce request has been acked by configured number of
 %% replicas in kafka cluster.
 %% @end
--spec produce(pid(), binary(), binary()) ->
+-spec produce(pid(), key(), value()) ->
         {ok, brod_call_ref()} | {error, any()}.
 produce(Pid, Key, Value) ->
   CallRef = #brod_call_ref{ caller = self()

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -192,7 +192,7 @@ init({ClientPid, Topic, Partition, Config}) ->
   MaybeCompress =
     fun(KafkaKvList) ->
       case Compression =/= no_compression andalso
-           batch_size(KafkaKvList) >= MinCompressBatchSize of
+           brod_utils:bytes(KafkaKvList) >= MinCompressBatchSize of
         true  -> Compression;
         false -> no_compression
       end
@@ -371,9 +371,6 @@ is_retriable(_) ->
         ok | {ok, corr_id()} | {error, any()}.
 sock_send(?undef, _KafkaReq) -> {error, sock_down};
 sock_send(SockPid, KafkaReq) -> brod_sock:request_async(SockPid, KafkaReq).
-
-batch_size([]) -> 0;
-batch_size([{K,V} | T]) -> size(K) + size(V) + batch_size(T).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -149,8 +149,8 @@ nack_all(#buf{onwire = OnWire} = Buf, Reason) ->
                   },
   {ok, rebuffer_or_crash(lists:append(AllOnWireReqs), NewBuf, Reason)}.
 
-%% @hidden Return true if there is no message pending,
-%% buffered or waiting for ack. Used in test only so far.
+%% @doc Return true if there is no message pending,
+%% buffered or waiting for ack.
 %% @end
 is_empty(#buf{ pending = []
              , buffer  = []
@@ -169,8 +169,10 @@ is_empty(#buf{}) -> false.
 assert_corr_id(_OnWireRequests = [], _CorrIdReceived) ->
   true;
 assert_corr_id([{CorrId, _Req} | _], CorrIdReceived) ->
-  not is_later_corr_id(CorrId, CorrIdReceived) orelse
-    exit({bad_order, CorrId, CorrIdReceived}).
+  case is_later_corr_id(CorrId, CorrIdReceived) of
+    true  -> exit({bad_order, CorrId, CorrIdReceived});
+    false -> true
+  end.
 
 %% @private Compare two corr-ids, return true if ID-2 is considered a 'later'
 %% one comparing to ID1.

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -339,12 +339,7 @@ cast(Pid, Msg) ->
   end.
 
 -spec data_size(key() | value()) -> non_neg_integer().
-data_size([]) -> 0;
-data_size(undefined) -> 0;
-data_size(B) when is_binary(B) -> size(B);
-data_size(I) when is_integer(I) andalso I < 256 andalso I >= 0 -> 1;
-data_size({K, V}) -> data_size(K) + data_size(V);
-data_size([H | T]) -> data_size(H) + data_size(T).
+data_size(Data) -> brod_utils:bytes(Data).
 
 %%%_* Tests ====================================================================
 

--- a/src/brod_sock.erl
+++ b/src/brod_sock.erl
@@ -167,7 +167,8 @@ init(Parent, Host, Port, ClientId, Options) ->
                 [] ->
                   State0#state{mod = gen_tcp, sock = Sock};
                 SslOpts ->
-                  error_logger:info_msg("Trying to establish ssl connection with options: ~p\n", [SslOpts]),
+                  error_logger:info_msg("Trying to establish ssl connection "
+                                        "with options: ~p\n", [SslOpts]),
                   case ssl:connect(Sock, SslOpts, Timeout) of
                     {ok, SslSock} ->
                       State0#state{mod = ssl, sock = SslSock};

--- a/src/brod_sock.erl
+++ b/src/brod_sock.erl
@@ -1,5 +1,5 @@
 %%%
-%%%   Copyright (c) 2014, 2015, Klarna AB
+%%%   Copyright (c) 2014-2016, Klarna AB
 %%%
 %%%   Licensed under the Apache License, Version 2.0 (the "License");
 %%%   you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 %%%=============================================================================
 %%% @doc
-%%% @copyright 2014, 2015 Klarna AB
+%%% @copyright 2014-2016 Klarna AB
 %%% @end
 %%% ============================================================================
 
@@ -32,7 +32,9 @@
         , loop/2
         , request_sync/3
         , request_async/2
+        , start/4
         , start/5
+        , start_link/4
         , start_link/5
         , stop/1
         , debug/2
@@ -56,25 +58,34 @@
                , sock        :: port()
                , tail = <<>> :: binary() %% leftover of last data stream
                , requests    :: brod_kafka_requests:requests()
+               , mod         :: gen_tcp | ssl
                }).
 
 %%%_* API ======================================================================
+%% @equiv start_link(Parent, Host, Port, ClientId, [])
+start_link(Parent, Host, Port, ClientId) ->
+  start_link(Parent, Host, Port, ClientId, []).
+
 -spec start_link(pid(), string(), integer(),
                  brod_client_id() | binary(), term()) ->
                     {ok, pid()} | {error, any()}.
-start_link(Parent, Host, Port, ClientId, Debug) when is_atom(ClientId) ->
+start_link(Parent, Host, Port, ClientId, Options) when is_atom(ClientId) ->
   BinClientId = list_to_binary(atom_to_list(ClientId)),
-  start_link(Parent, Host, Port, BinClientId, Debug);
-start_link(Parent, Host, Port, ClientId, Debug) when is_binary(ClientId) ->
-  proc_lib:start_link(?MODULE, init, [Parent, Host, Port, ClientId, Debug]).
+  start_link(Parent, Host, Port, BinClientId, Options);
+start_link(Parent, Host, Port, ClientId, Options) when is_binary(ClientId) ->
+  proc_lib:start_link(?MODULE, init, [Parent, Host, Port, ClientId, Options]).
+
+%% @equiv start(Parent, Host, Port, ClientId, [])
+start(Parent, Host, Port, ClientId) ->
+  start(Parent, Host, Port, ClientId, []).
 
 -spec start(pid(), string(), integer(), brod_client_id() | binary(), term()) ->
                {ok, pid()} | {error, any()}.
-start(Parent, Host, Port, ClientId, Debug) when is_atom(ClientId) ->
+start(Parent, Host, Port, ClientId, Options) when is_atom(ClientId) ->
   BinClientId = list_to_binary(atom_to_list(ClientId)),
-  start(Parent, Host, Port, BinClientId, Debug);
-start(Parent, Host, Port, ClientId, Debug) when is_binary(ClientId) ->
-  proc_lib:start(?MODULE, init, [Parent, Host, Port, ClientId, Debug]).
+  start(Parent, Host, Port, BinClientId, Options);
+start(Parent, Host, Port, ClientId, Options) when is_binary(ClientId) ->
+  proc_lib:start(?MODULE, init, [Parent, Host, Port, ClientId, Options]).
 
 -spec request_async(pid(), term()) -> {ok, corr_id()} | ok | {error, any()}.
 request_async(Pid, Request) ->
@@ -139,20 +150,35 @@ debug(Pid, File) when is_list(File) ->
 
 -spec init(pid(), hostname(), portnum(), brod_client_id(), [any()]) ->
         no_return().
-init(Parent, Host, Port, ClientId, Debug0) ->
-  Debug = sys:debug_options(Debug0),
+init(Parent, Host, Port, ClientId, Options) ->
+  Debug = sys:debug_options(proplists:get_value(debug, Options, [])),
+  Timeout = proplists:get_value(timeout, Options, ?CONNECT_TIMEOUT),
   SockOpts = [{active, true}, {packet, raw}, binary, {nodelay, true}],
-  case gen_tcp:connect(Host, Port, SockOpts, ?CONNECT_TIMEOUT) of
+  case gen_tcp:connect(Host, Port, SockOpts, Timeout) of
     {ok, Sock} ->
+      State0 = #state{client_id = ClientId, parent = Parent},
+      %% adjusting buffer size as per recommendation at
+      %% http://erlang.org/doc/man/inet.html#setopts-2
+      %% idea is from github.com/epgsql/epgsql
+      {ok, [{recbuf, RecBufSize}, {sndbuf, SndBufSize}]} =
+        inet:getopts(Sock, [recbuf, sndbuf]),
+      ok = inet:setopts(Sock, [{buffer, max(RecBufSize, SndBufSize)}]),
+      State = case proplists:get_value(ssl, Options, []) of
+                [] ->
+                  State0#state{mod = gen_tcp, sock = Sock};
+                SslOpts ->
+                  error_logger:info_msg("Trying to establish ssl connection with options: ~p\n", [SslOpts]),
+                  case ssl:connect(Sock, SslOpts, Timeout) of
+                    {ok, SslSock} ->
+                      State0#state{mod = ssl, sock = SslSock};
+                    {error, Reason} ->
+                      exit({ssl_negotiation_failure, Reason})
+                  end
+              end,
       proc_lib:init_ack(Parent, {ok, self()}),
       try
         Requests = brod_kafka_requests:new(),
-        State = #state{ client_id = ClientId
-                      , parent    = Parent
-                      , sock      = Sock
-                      , requests  = Requests
-                      },
-        loop(State, Debug)
+        loop(State#state{requests = Requests}, Debug)
       catch error : E ->
         Stack = erlang:get_stacktrace(),
         exit({E, Stack})
@@ -160,7 +186,7 @@ init(Parent, Host, Port, ClientId, Debug0) ->
     {error, Reason} ->
       %% exit instead of {error, Reason}
       %% otherwise exit reason will be 'normal'
-      exit(Reason)
+      exit({connection_failure, Reason})
   end.
 
 system_call(Pid, Request) ->
@@ -200,11 +226,11 @@ decode_msg(Msg, State, Debug0) ->
   Debug = sys:handle_debug(Debug0, fun print_msg/3, State, Msg),
   handle_msg(Msg, State, Debug).
 
-handle_msg({tcp, _Sock, Bin}, #state{ tail     = Tail0
-                                    , requests = Requests
-                                    } = State, Debug) ->
-  Stream = <<Tail0/binary, Bin/binary>>,
-  {Responses, Tail} = kpro:decode_response(Stream),
+handle_msg({_, Sock, Bin}, #state{ sock     = Sock
+                                 , tail     = Tail0
+                                 , requests = Requests
+                                 } = State, Debug) ->
+  {Responses, Tail} = kpro:decode_response(<<Tail0/binary, Bin/binary>>),
   NewRequests =
     lists:foldl(
       fun(#kpro_Response{ correlationId   = CorrId
@@ -215,26 +241,31 @@ handle_msg({tcp, _Sock, Bin}, #state{ tail     = Tail0
         brod_kafka_requests:del(Reqs, CorrId)
       end, Requests, Responses),
   ?MODULE:loop(State#state{tail = Tail, requests = NewRequests}, Debug);
-handle_msg({tcp_closed, _Sock}, _State, _) ->
+handle_msg({tcp_closed, Sock}, #state{sock = Sock}, _) ->
   exit({shutdown, tcp_closed});
-handle_msg({tcp_error, _Sock, Reason}, _State, _) ->
+handle_msg({ssl_closed, Sock}, #state{sock = Sock}, _) ->
+  exit({shutdown, ssl_closed});
+handle_msg({tcp_error, Sock, Reason}, #state{sock = Sock}, _) ->
   exit({tcp_error, Reason});
+handle_msg({ssl_error, Sock, Reason}, #state{sock = Sock}, _) ->
+  exit({ssl_error, Reason});
 handle_msg({From, {send, Request}},
            #state{ client_id = ClientId
+                 , mod       = Mod
                  , sock      = Sock
                  , requests  = Requests
                  } = State, Debug) ->
   {Caller, _Ref} = From,
   {CorrId, NewRequests} = brod_kafka_requests:add(Requests, Caller),
   RequestBin = kpro:encode_request(ClientId, CorrId, Request),
-  ok = gen_tcp:send(Sock, RequestBin),
+  ok = Mod:send(Sock, RequestBin),
   reply(From, {ok, CorrId}),
   ?MODULE:loop(State#state{requests = NewRequests}, Debug);
 handle_msg({From, get_tcp_sock}, State, Debug) ->
   _ = reply(From, {ok, State#state.sock}),
   ?MODULE:loop(State, Debug);
-handle_msg({From, stop}, #state{sock = Sock}, _Debug) ->
-  gen_tcp:close(Sock),
+handle_msg({From, stop}, #state{mod = Mod, sock = Sock}, _Debug) ->
+  Mod:close(Sock),
   _ = reply(From, ok),
   ok;
 handle_msg(Msg, State, Debug) ->

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -118,8 +118,8 @@ start_link(Client, Topic, Partitions, ConsumerConfig, CbModule, CbInitArg) ->
 %% messages from the given partition set. Use atom 'all' to subscribe to all
 %% partitions. Messages are handled by calling the callback function.
 %% @end
--spec start_link(client(), topic(), all | [partition()],
-                 consumer_config(), committed_offsets(), cb_fun(), cb_state()) ->
+-spec start_link(client(), topic(), all | [partition()], consumer_config(),
+                 committed_offsets(), cb_fun(), cb_state()) ->
         {ok, pid()} | {error, any()}.
 start_link(Client, Topic, Partitions, ConsumerConfig,
            CommittedOffsets, CbFun, CbInitialState) ->

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -23,7 +23,8 @@
 -module(brod_utils).
 
 %% Exports
--export([ find_leader_in_metadata/3
+-export([ bytes/1
+        , find_leader_in_metadata/3
         , get_metadata/1
         , get_metadata/2
         , is_normal_reason/1
@@ -190,6 +191,16 @@ do_find_leader_in_metadata(Metadata, Topic, Partition) ->
   Host = Broker#kpro_Broker.host,
   Port = Broker#kpro_Broker.port,
   {binary_to_list(Host), Port}.
+
+-define(IS_BYTE(I), (I>=0 andalso I<256)).
+
+-spec bytes(key() | value() | kv_list()) -> non_neg_integer().
+bytes([]) -> 0;
+bytes(undefined) -> 0;
+bytes(I) when ?IS_BYTE(I) -> 1;
+bytes(B) when is_binary(B) -> erlang:size(B);
+bytes({K, V}) -> bytes(K) + bytes(V);
+bytes([H | T]) -> bytes(H) + bytes(T).
 
 %%%_* Tests ====================================================================
 

--- a/sys.config.example
+++ b/sys.config.example
@@ -4,7 +4,7 @@
      %% A client manages a set of tcp connections for all
      %% producers and consumers under its hierarchy.
      %% see brod_sup.erl for more details about supervision tree
-     , [ { brod_client_1
+     , [ { c1
          , [ { endpoints, [{"localhost", 9092}]}
            , { config
              , [ {restart_delay_seconds, 10}
@@ -15,6 +15,24 @@
                   , {required_acks, -1}
                   ]
                  }
+               ]
+             }
+           ]
+         }
+       , { c2
+         , [ { endpoints, [{"localhost", 9093}]}
+           , { config
+             , [ {restart_delay_seconds, 10}
+               , {auto_start_producers, true}
+               , {default_producer_config,
+                  [ {topic_restart_delay_seconds, 10}
+                  , {partition_restart_delay_seconds, 2}
+                  , {required_acks, -1}
+                  ]
+                 }
+               , {ssl, [ {certfile, "client.crt"}
+                       , {keyfile, "client.key"}
+                       , {cacertfile, "ca.crt"}]}
                ]
              }
            ]

--- a/test/brod_client_SUITE.erl
+++ b/test/brod_client_SUITE.erl
@@ -121,7 +121,7 @@ t_no_reachable_endpoint(Config) when is_list(Config) ->
   ClientPid = whereis(Client),
   Mref = erlang:monitor(process, ClientPid),
   Reason = ?WAIT({'DOWN', Mref, process, ClientPid, Reason_}, Reason_, 1000),
-  ?assertMatch({{nxdomain, _Hosts}, _Stacktrace}, Reason).
+  ?assertMatch({{{connection_failure, nxdomain}, _Hosts}, _Stacktrace}, Reason).
 
 t_call_bad_client_id(Config) when is_list(Config) ->
   %% call a bad client ID

--- a/test/brod_compression_SUITE.erl
+++ b/test/brod_compression_SUITE.erl
@@ -34,9 +34,11 @@
 
 %% Test cases
 -export([ t_produce_gzip/1
-        %, t_produce_snappy/1
+        , t_produce_snappy/1
+        %, t_produce_lz4/1
         , t_produce_compressed_batch_consume_from_middle_gzip/1
-        %, t_produce_compressed_batch_consume_from_middle_snappy/1
+        , t_produce_compressed_batch_consume_from_middle_snappy/1
+        %, t_produce_compressed_batch_consume_from_middle_lz4/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -91,14 +93,20 @@ all() -> [F || {F, _A} <- module_info(exports),
 t_produce_gzip(Config) ->
   run(fun produce/1, gzip, Config).
 
-%t_produce_snappy(Config) ->
-%  run(fun produce/1, snappy, Config).
+t_produce_snappy(Config) ->
+  run(fun produce/1, snappy, Config).
+
+%t_produce_lz4(Config) ->
+%  run(fun produce/1, lz4, Config).
 
 t_produce_compressed_batch_consume_from_middle_gzip(Config) ->
   run(fun produce_compressed_batch_consume_from_middle/1, gzip, Config).
 
-%t_produce_compressed_batch_consume_from_middle_snappy(Config) ->
-%  run(fun produce_compressed_batch_consume_from_middle/1, snappy, Config).
+t_produce_compressed_batch_consume_from_middle_snappy(Config) ->
+  run(fun produce_compressed_batch_consume_from_middle/1, snappy, Config).
+
+%t_produce_compressed_batch_consume_from_middle_lz4(Config) ->
+%  run(fun produce_compressed_batch_consume_from_middle/1, lz4, Config).
 
 %%%_* Help functions ===========================================================
 

--- a/test/brod_demo_cg_collector.erl
+++ b/test/brod_demo_cg_collector.erl
@@ -46,6 +46,8 @@
         , handle_message/3
         ]).
 
+-record(state, {ets}).
+
 start() ->
   start([{"localhost", 9092}]).
 start(BootstrapHosts) ->
@@ -65,10 +67,10 @@ start(BootstrapHosts, ClientId, CgTopic, EtsName) ->
 
 init(_Topic, EtsName) ->
   EtsName = ets:new(EtsName, [named_table, ordered_set, public]),
-  {ok, [], #{ets => EtsName}}.
+  {ok, [], #state{ets = EtsName}}.
 
 handle_message(_Partition, #kafka_message{key = KeyBin, value = ValueBin},
-               #{ets := Ets} = State) ->
+               #state{ets = Ets} = State) ->
   {Tag, Key, Value} = kpro_consumer_group:decode(KeyBin, ValueBin),
   Kf = fun(K) -> {K, V} = lists:keyfind(K, 1, Key), V end,
   case Tag of

--- a/test/brod_demo_cg_collector.erl
+++ b/test/brod_demo_cg_collector.erl
@@ -1,0 +1,90 @@
+%%%
+%%%   Copyright (c) 2016 Klarna AB
+%%%
+%%%   Licensed under the Apache License, Version 2.0 (the "License");
+%%%   you may not use this file except in compliance with the License.
+%%%   You may obtain a copy of the License at
+%%%
+%%%       http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%%   Unless required by applicable law or agreed to in writing, software
+%%%   distributed under the License is distributed on an "AS IS" BASIS,
+%%%   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%%   See the License for the specific language governing permissions and
+%%%   limitations under the License.
+%%%
+
+%%%=============================================================================
+%%% @doc
+%%% This is a topic subscriber example
+%%% The subscriber subscribes to all partition of the consumer offset topic
+%%% (by default __consumer_offsets), decode the messages and put the values
+%%% to an ETS table.
+%%% see kpro_consumer_group.erl for details about data schema
+%%% @copyright 2016 Klarna AB
+%%% @end
+%%%=============================================================================
+
+-module(brod_demo_cg_collector).
+
+-behaviour(brod_topic_subscriber).
+
+-include_lib("brod/include/brod.hrl").
+
+-define(CLIENT, ?MODULE).
+-define(ETS, consumer_offsets).
+
+-export([ start/0
+        , start/1
+        , start/2
+        , start/3
+        , start/4
+        ]).
+
+%% brod_topic_subscriber callback
+-export([ init/2
+        , handle_message/3
+        ]).
+
+start() ->
+  start([{"localhost", 9092}]).
+start(BootstrapHosts) ->
+  start(BootstrapHosts, ?CLIENT).
+start(BootstrapHosts, ClientId) ->
+  start(BootstrapHosts, ClientId, <<"__consumer_offsets">>).
+start(BootstrapHosts, ClientId, CgTopic) ->
+  start(BootstrapHosts, ClientId, CgTopic, ?ETS).
+
+start(BootstrapHosts, ClientId, CgTopic, EtsName) ->
+  ClientConfig = [],
+  {ok, _} = application:ensure_all_started(brod),
+  ok = brod:start_client(BootstrapHosts, ClientId, ClientConfig),
+  brod_topic_subscriber:start_link(ClientId, CgTopic, _Partitions = all,
+                                   [{begin_offset, earliest}],
+                                   ?MODULE, EtsName).
+
+init(_Topic, EtsName) ->
+  EtsName = ets:new(EtsName, [named_table, ordered_set, public]),
+  {ok, [], #{ets => EtsName}}.
+
+handle_message(_Partition, #kafka_message{key = KeyBin, value = ValueBin},
+               #{ets := Ets} = State) ->
+  {Tag, Key, Value} = kpro_consumer_group:decode(KeyBin, ValueBin),
+  Kf = fun(K) -> {K, V} = lists:keyfind(K, 1, Key), V end,
+  case Tag of
+    offset -> update_ets(Ets, {Kf(group_id), Kf(topic), Kf(partition)}, Value);
+    group  -> update_ets(Ets, Kf(group_id), Value)
+  end,
+  {ok, ack, State}.
+
+%%%_* Internal Functions =======================================================
+
+update_ets(Ets, Key, _Value = []) -> ets:delete(Ets, Key);
+update_ets(Ets, Key, Value)       -> ets:insert(Ets, {Key, Value}).
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:
+

--- a/test/brod_demo_topic_subscriber.erl
+++ b/test/brod_demo_topic_subscriber.erl
@@ -16,10 +16,7 @@
 
 %%%=============================================================================
 %%% @doc
-%%% This is a consumer group subscriber example
-%%% This is called 'loc' as in 'Local Offset Commit'. i.e. it demos an
-%%% implementation of group subscriber that writes offsets locally (to file
-%%% in this module), but does not commit offsets to Kafka.
+%%% This is a topic subscriber example
 %%% @copyright 2016 Klarna AB
 %%% @end
 %%%=============================================================================
@@ -74,7 +71,7 @@ bootstrap(DelaySeconds) ->
   ok = spawn_producers(ClientId, Topic, DelaySeconds, Partitions),
   ok.
 
-%% @doc Initialize nothing in our case.
+%% @doc Get committed offsets from file `/tmp/<topic>'
 init(Topic, []) ->
   OffsetDir = filename:join(["/tmp", Topic]),
   Offsets = read_offsets(OffsetDir),

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -39,6 +39,7 @@
         , t_producer_topic_not_found/1
         , t_producer_partition_not_found/1
         , t_produce_partitioner/1
+        , t_produce_batch/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -234,6 +235,29 @@ t_produce_partitioner(Config) when is_list(Config) ->
   ReceiveFun(0, K1, V1),
   ok = brod:produce_sync(Client, ?TOPIC, PartFun, K2, V2),
   ReceiveFun(1, K2, V2).
+
+t_produce_batch(Config) when is_list(Config) ->
+  Client = ?config(client),
+  Partition = 0,
+  {K1, V1} = make_unique_kv(),
+  {K2, V2} = make_unique_kv(),
+  {K3, V3} = make_unique_kv(),
+  Batch = [{K1, V1}, {K2, V2}, {<<>>, [{K3, V3}]}],
+  ok = brod:produce_sync(Client, ?TOPIC, Partition, undefined, Batch),
+  ReceiveFun =
+    fun(ExpectedK, ExpectedV) ->
+      receive
+        {_, K, V} ->
+          ?assertEqual(ExpectedK, K),
+          ?assertEqual(ExpectedV, V)
+        after 5000 ->
+          ct:fail({?MODULE, ?LINE, timeout, ExpectedK, ExpectedV})
+      end
+    end,
+  ReceiveFun(K1, V1),
+  ReceiveFun(K2, V2),
+  ReceiveFun(K3, V3).
+
 
 %%%_* Help functions ===========================================================
 

--- a/test/brod_producer_buffer_SUITE.erl
+++ b/test/brod_producer_buffer_SUITE.erl
@@ -66,10 +66,12 @@ all() -> [F || {F, _A} <- module_info(exports),
 %%%_* Test functions ===========================================================
 
 t_no_ack(Config) when is_list(Config) ->
-  ?assert(proper:quickcheck(prop_no_ack_run(), 1000)).
+  Opts = [{numtests, 1000}, {to_file, user}],
+  ?assert(proper:quickcheck(prop_no_ack_run(), Opts)).
 
 t_random_latency_ack(Config) when is_list(Config) ->
-  ?assert(proper:quickcheck(prop_random_latency_ack_run(), 500)).
+  Opts = [{numtests, 500}, {to_file, user}],
+  ?assert(proper:quickcheck(prop_random_latency_ack_run(), Opts)).
 
 t_nack(Config) when is_list(Config) ->
   SendFun =


### PR DESCRIPTION
Features:
- Batch-by-caller producing
- TLS encryption
- Snappy compression/decompression (via kafka_protocol 0.7)

Enhancements:
- No immediate connection re-establish in case producer has nothing to send in buffer
- Shrink `max_bytes` after expansion
- Use `queue:queue()` to avoid `++` operations in producer buffer (by @eriklee)
- Improve `brod_topic_subscriber` and `brod_group_subscriber` performance

Bugs:
- Producer buffer size indefinite growth (by @eriklee) (also fixed in 2.1)
- Consumer filter offsets based on begin_offset for compressed batch delivery (also fixed in 2.1) 
- Fix compression batch size calculation crash (introduced in 2.2-dev)
- Fix group coordinator connection SSL issue (by @eriosv) (introduced in 2.2-dev)

Misc:
- Consumer group data collector as topic subscriber demo
- Version integrity checks in travis
