### PR TITLE
fix consumer subscriber acks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.2.2
+PROJECT_VERSION = 2.2.3
 
 DEPS = supervisor3 kafka_protocol
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.2.2"},
+  {vsn,"2.2.3"},
   {registered,[]},
   {applications,[kernel,stdlib,supervisor3,kafka_protocol]},
   {env,[]},

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -371,9 +371,9 @@ handle_messages(Topic, Partition, [Msg | Rest], State) ->
   {AckNow, NewCbState} =
     case CbModule:handle_message(Topic, Partition, Msg, CbState) of
       {ok, NewCbState_} ->
-        {true, NewCbState_};
-      {ok, ack, NewCbState_} ->
         {false, NewCbState_};
+      {ok, ack, NewCbState_} ->
+        {true, NewCbState_};
       Unknown ->
         erlang:error({bad_return_value,
                      {CbModule, handle_message, Unknown}})

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -295,9 +295,9 @@ handle_messages(Partition, [Msg | Rest], State) ->
   {AckNow, NewCbState} =
     case CbFun(Partition, Msg, CbState) of
       {ok, NewCbState_} ->
-        {true, NewCbState_};
-      {ok, ack, NewCbState_} ->
         {false, NewCbState_};
+      {ok, ack, NewCbState_} ->
+        {true, NewCbState_};
       Unknown ->
         erlang:error({bad_return_value, handle_message, Unknown})
     end,


### PR DESCRIPTION
fixes #119 
introduced in 2.1.11 , also affected releases 2.2.0, 2.2.1, 2.2.2
the AckNow logic is implemented in the other way around for both topic and group subscribers.
