### PR TITLE
rename second level per-topic supervisor MACROs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,10 @@ script:
   - echo "verifying rebar compilation"
   - rebar get-deps
   - rebar compile
-  - rm rebar.lock # delete rebar.lock so it gets re-created, expecting no diff
   - make distclean
   - echo "verifying rebar3 compilation"
-  - wget https://s3.amazonaws.com/rebar3/rebar3
-  - chmod +x rebar3
-  - ./rebar3 compile
-  - DIFF=$(git diff rebar.lock); if [ -n "$DIFF" ]; then echo 'rebar.lock discrepancy'; exit 1; fi;
+  - git clone https://github.com/erlang/rebar3.git; cd rebar3; ./bootstrap; cd ..
+  - ./rebar3/rebar3 compile
   - make distclean
   - make escript
   - make test-env

--- a/src/brod_producers_sup.erl
+++ b/src/brod_producers_sup.erl
@@ -34,14 +34,14 @@
 
 -include("brod_int.hrl").
 
--define(SUP, brod_producers_sup).
--define(SUP2, brod_producers_sup2).
+-define(TOPICS_SUP, brod_producers_sup).
+-define(PARTITIONS_SUP, brod_producers_sup2).
 
 %% Minimum delay seconds to work with supervisor3
 -define(MIN_SUPERVISOR3_DELAY_SECS, 1).
 
-%% By default, restart sup2 after a 10-seconds delay
--define(DEFAULT_SUP2_RESTART_DELAY, 10).
+%% By default, restart ?PARTITIONS_SUP after a 10-seconds delay
+-define(DEFAULT_PARTITIONS_SUP_RESTART_DELAY, 10).
 
 %% By default, restart partition producer worker process after a 5-seconds delay
 -define(DEFAULT_PRODUCER_RESTART_DELAY, 5).
@@ -53,7 +53,7 @@
 %% @end
 -spec start_link() -> {ok, pid()}.
 start_link() ->
-  supervisor3:start_link(?MODULE, ?SUP).
+  supervisor3:start_link(?MODULE, ?TOPICS_SUP).
 
 %% @doc Dynamically start a per-topic supervisor
 -spec start_producer(pid(), pid(), topic(), producer_config()) ->
@@ -67,7 +67,7 @@ start_producer(SupPid, ClientPid, TopicName, Config) ->
 stop_producer(SupPid, TopicName) ->
   supervisor3:terminate_child(SupPid, TopicName).
 
-%% @doc Find a brod_producer process pid running under sup2.
+%% @doc Find a brod_producer process pid running under ?PARTITIONS_SUP.
 -spec find_producer(pid(), topic(), partition()) ->
                        {ok, pid()} | {error, Reason} when
         Reason :: {producer_not_found, topic()}
@@ -79,9 +79,9 @@ find_producer(SupPid, Topic, Partition) ->
       %% no such topic worker started,
       %% check sys.config or brod:start_link_client args
       {error, {producer_not_found, Topic}};
-    [Sup2Pid] ->
+    [PartitionsSupPid] ->
       try
-        case supervisor3:find_child(Sup2Pid, Partition) of
+        case supervisor3:find_child(PartitionsSupPid, Partition) of
           [] ->
             %% no such partition?
             {error, {producer_not_found, Topic, Partition}};
@@ -94,12 +94,12 @@ find_producer(SupPid, Topic, Partition) ->
   end.
 
 %% @doc supervisor3 callback.
-init(?SUP) ->
+init(?TOPICS_SUP) ->
   {ok, {{one_for_one, 0, 1}, []}};
-init({?SUP2, _ClientPid, _Topic, _Config}) ->
+init({?PARTITIONS_SUP, _ClientPid, _Topic, _Config}) ->
   post_init.
 
-post_init({?SUP2, ClientPid, Topic, Config}) ->
+post_init({?PARTITIONS_SUP, ClientPid, Topic, Config}) ->
   case brod_client:get_partitions_count(ClientPid, Topic) of
     {ok, PartitionsCnt} ->
       Children = [ producer_spec(ClientPid, Topic, Partition, Config)
@@ -117,8 +117,8 @@ post_init({?SUP2, ClientPid, Topic, Config}) ->
 producers_sup_spec(ClientPid, TopicName, Config0) ->
   {Config, DelaySecs} =
     take_delay_secs(Config0, topic_restart_delay_seconds,
-                    ?DEFAULT_SUP2_RESTART_DELAY),
-  Args = [?MODULE, {?SUP2, ClientPid, TopicName, Config}],
+                    ?DEFAULT_PARTITIONS_SUP_RESTART_DELAY),
+  Args = [?MODULE, {?PARTITIONS_SUP, ClientPid, TopicName, Config}],
   { _Id       = TopicName
   , _Start    = {supervisor3, start_link, Args}
   , _Restart  = {permanent, DelaySecs}

--- a/test/brod_demo_group_subscriber_koc.erl
+++ b/test/brod_demo_group_subscriber_koc.erl
@@ -55,7 +55,7 @@
 %% @doc This function bootstraps everything to demo group subscribers.
 %% Prerequisites:
 %%   - bootstrap docker host at {"localhost", 9092}
-%%   - kafka topic named <<"brod-group-subscriber-demo-koc">>
+%%   - kafka topic named <<"brod-demo-group-subscriber-koc">>
 %% Processes to spawn:
 %%   - A brod client
 %%   - A producer which produces sequence numbers to each partition


### PR DESCRIPTION
SUP -> TOPICS_SUP
SUP2 -> PARTITIONS_SUP
keeping the actual name unchanged (e.g. brod_producers_sup2)
to be backword compatible. otherwise a full supervision tree
restart is required when load recompiled beam.
