### PR TITLE
fix off-by-one error check

### DIFF
--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -270,7 +270,7 @@ subscribe_partition(Client, Topic, Consumer) ->
             %% the default or configured 'begin_offset' will be used
             [];
           false ->
-            AckedOffset >= 0 orelse erlang:error({invalid_offset, AckedOffset}),
+            AckedOffset >= -1 orelse erlang:error({invalid_offset, AckedOffset}),
             [{begin_offset, AckedOffset+1}]
         end,
       case brod:subscribe(Client, self(), Topic, Partition, Options) of


### PR DESCRIPTION
Consuming the first message isn't possible due to an off-by-one error in an
input check.