### PR TITLE
Batch on retry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.2.10
+PROJECT_VERSION = 2.2.11
 
 DEPS = supervisor3 kafka_protocol
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.2.10"},
+  {vsn,"2.2.11"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_kafka_requests.erl
+++ b/src/brod_kafka_requests.erl
@@ -34,7 +34,7 @@
         , del/2
         , get_caller/2
         , get_corr_id/1
-	, increment_corr_id/1
+        , increment_corr_id/1
         ]).
 
 -export_type([requests/0]).

--- a/sys.config.example
+++ b/sys.config.example
@@ -5,36 +5,32 @@
      %% producers and consumers under its hierarchy.
      %% see brod_sup.erl for more details about supervision tree
      , [ { c1
-         , [ { endpoints, [{"localhost", 9092}]}
-           , { config
-             , [ {restart_delay_seconds, 10}
-               , {auto_start_producers, true}
-               , {default_producer_config,
-                  [ {topic_restart_delay_seconds, 10}
-                  , {partition_restart_delay_seconds, 2}
-                  , {required_acks, -1}
-                  ]
-                 }
+         , [ {endpoints, [{"localhost", 9092}]}
+           , {restart_delay_seconds, 10}
+           , {auto_start_producers, true}
+           , {default_producer_config,
+               [ {topic_restart_delay_seconds, 10}
+               , {partition_restart_delay_seconds, 2}
+               , {required_acks, -1}
                ]
              }
            ]
          }
        , { c2
-         , [ { endpoints, [{"localhost", 9093}]}
-           , { config
-             , [ {restart_delay_seconds, 10}
-               , {auto_start_producers, true}
-               , {default_producer_config,
-                  [ {topic_restart_delay_seconds, 10}
-                  , {partition_restart_delay_seconds, 2}
-                  , {required_acks, -1}
-                  ]
-                 }
-               , {ssl, [ {certfile, "client.crt"}
-                       , {keyfile, "client.key"}
-                       , {cacertfile, "ca.crt"}]}
+         , [ {endpoints, [{"localhost", 9093}]}
+           , {restart_delay_seconds, 10}
+           , {auto_start_producers, true}
+           , {default_producer_config,
+               [ {topic_restart_delay_seconds, 10}
+               , {partition_restart_delay_seconds, 2}
+               , {required_acks, -1}
                ]
              }
+           , {ssl,
+               [ {certfile, "client.crt"}
+               , {keyfile, "client.key"}
+               , {cacertfile, "ca.crt"}
+               ]}
            ]
          }
        ]


### PR DESCRIPTION
'retry slow' and 'retry one at a time' seem to be over engineered.
As reported in #155, (especially when the message sizes are small and buffer size is large), it may take quite long time to recover.

As for strict ordering, as long as onwire_limit is larger than 1, the risk of breaking it is always there.
I might have missed something though, @id please check me.

