### PR TITLE
Add SASL/Plain authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.2.16
+PROJECT_VERSION = 2.3.0
 
 DEPS = supervisor3 kafka_protocol
 
 dep_supervisor3_commit = 1.1.5
-dep_kafka_protocol_commit = 0.7.8
+dep_kafka_protocol_commit = 0.8.0
 
 TEST_DEPS = meck proper
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Why "brod"? [http://en.wikipedia.org/wiki/Max_Brod](http://en.wikipedia.org/wiki
 * lz4 compression & decompression
 * new 0.10 on-wire message format
 * new 0.10.1.0 create/delete topic api
-* SASL authentication
 
 # Building and testing
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY server.properties /etc/kafka/server.properties
 COPY server.jks /etc/kafka/server.jks
 COPY truststore.jks /etc/kafka/truststore.jks
+COPY jaas.conf /etc/kafka/jaas.conf
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/docker/docker-compose-kafka-1.yml
+++ b/docker/docker-compose-kafka-1.yml
@@ -11,8 +11,10 @@ services:
     ports:
       - "9092:9092"
       - "9192:9192"
+      - "9292:9292"
     environment:
       BROKER_ID: 0
       PLAINTEXT_PORT: 9092
       SSL_PORT: 9192
+      SASL_SSL_PORT: 9292
 

--- a/docker/docker-compose-kafka-2.yml
+++ b/docker/docker-compose-kafka-2.yml
@@ -11,19 +11,22 @@ services:
     ports:
       - "9092:9092"
       - "9192:9192"
+      - "9292:9292"
     environment:
       BROKER_ID: 0
       PLAINTEXT_PORT: 9092
       SSL_PORT: 9192
+      SASL_SSL_PORT: 9292
   kafka_2:
     image: docker_kafka
     container_name: kafka_2
     ports:
       - "9093:9093"
       - "9193:9193"
+      - "9293:9293"
     environment:
       BROKER_ID: 1
       PLAINTEXT_PORT: 9093
       SSL_PORT: 9193
-
+      SASL_SSL_PORT: 9293
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,8 +28,10 @@ fi
 ipwithnetmask="$(ip -f inet addr show dev eth0 | awk '/inet / { print $2 }')"
 ipaddress="${ipwithnetmask%/*}"
 
-sed -r -i "s/^(advertised.listeners)=(.*)/\1=PLAINTEXT:\/\/$ipaddress:$PLAINTEXT_PORT,SSL:\/\/$ipaddress:$SSL_PORT/g" $prop_file
-sed -r -i "s/^(listeners)=(.*)/\1=PLAINTEXT:\/\/:$PLAINTEXT_PORT,SSL:\/\/:$SSL_PORT/g" $prop_file
+sed -r -i "s/^(advertised.listeners)=(.*)/\1=PLAINTEXT:\/\/$ipaddress:$PLAINTEXT_PORT,SSL:\/\/$ipaddress:$SSL_PORT,SASL_SSL:\/\/$ipaddress:$SASL_SSL_PORT/g" $prop_file
+sed -r -i "s/^(listeners)=(.*)/\1=PLAINTEXT:\/\/:$PLAINTEXT_PORT,SSL:\/\/:$SSL_PORT,SASL_SSL:\/\/:$SASL_SSL_PORT/g" $prop_file
+echo "sasl.enabled.mechanisms=PLAIN" >> $prop_file
 
-/opt/kafka/bin/kafka-server-start.sh $prop_file
+KAFKA_HEAP_OPTS="-Xmx1G -Xms1G -Djava.security.auth.login.config=/etc/kafka/jaas.conf" \
+  /opt/kafka/bin/kafka-server-start.sh $prop_file
 

--- a/docker/jaas.conf
+++ b/docker/jaas.conf
@@ -1,0 +1,5 @@
+KafkaServer {
+   org.apache.kafka.common.security.plain.PlainLoginModule required
+   user_admin="admin-secret"
+   user_alice="alice-secret";
+};

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [ {supervisor3, "1.1.5"}
-       , {kafka_protocol, "0.7.8"}
+       , {kafka_protocol, "0.8.0"}
        ]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.2.16"},
+  {vsn,"2.3.0"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -179,6 +179,9 @@ start_client(BootstrapEndpoints, ClientId) ->
 %%       true | false | [{certfile, ...},{keyfile, ...},{cacertfile, ...}]
 %%       When true, brod will try to upgrade tcp connection to ssl using default
 %%       ssl options. List of ssl options implies ssl=true.
+%%     sasl (optional, default=undefined)
+%%       Credentials for SASL/Plain authentication.
+%%       {plain, "username", "password"}
 %%     connect_timeout (optional, default=5000)
 %%       Timeout when trying to connect to one endpoint.
 %%     request_timeout (optional, default=120000, constraint: >= 1000)


### PR DESCRIPTION
requires https://github.com/klarna/kafka_protocol/pull/25

Erlang newbie here, so I'm all ears for your suggestions. `maybe_sasl_auth` looks pretty ugly IMHO. Also SASL error handling/reporting could be better, probably. I have no idea how (and if) to test for SASL errors.