### PR TITLE
Take produce req from pending to buffer more actively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.3.2
+PROJECT_VERSION = 2.3.3
 
 DEPS = supervisor3 kafka_protocol
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.3.2"},
+  {vsn,"2.3.3"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -174,7 +174,7 @@ start_client(BootstrapEndpoints, ClientId) ->
 %%       which don't know beforehand which topics they will be working with.
 %%     default_producer_config (optional, default=[])
 %%       Producer configuration to use when auto_start_producers is true.
-%%       @see brod_client:start_producer/3. for more details.
+%%       @see brod_producer:start_link/4. for details about producer config
 %%     ssl (optional, default=false)
 %%       true | false | [{certfile, ...},{keyfile, ...},{cacertfile, ...}]
 %%       When true, brod will try to upgrade tcp connection to ssl using default
@@ -223,7 +223,7 @@ stop_client(Client) when is_pid(Client) ->
   brod_client:stop(Client).
 
 %% @doc Dynamically start a per-topic producer.
-%% @see brod_client:start_producer/3. for more details.
+%% @see brod_producer:start_link/4. for details about producer config.
 %% @end
 -spec start_producer(client(), topic(), producer_config()) ->
                         ok | {error, any()}.
@@ -231,7 +231,7 @@ start_producer(Client, TopicName, ProducerConfig) ->
   brod_client:start_producer(Client, TopicName, ProducerConfig).
 
 %% @doc Dynamically start a topic consumer.
-%% @see brod_client:start_consumer/3. for more details.
+%% @see brod_consumer:start_link/5. for details about consumer config.
 %% @end
 -spec start_consumer(client(), topic(), consumer_config()) ->
                         ok | {error, any()}.

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -381,11 +381,11 @@ handle_add_offset(#pending_acks{ offsets_queue = Queue
   NewQueue =
     case queue:out_r(Queue) of
       {{value, {Begin, End}}, Queue1} when End =:= Offset + 1 ->
-        %% the incoming offset is sucessive to the offset rage at queue rear
+        %% the incoming offset is successive to the offset range at queue rear
         %% expand the range
         queue:in({Begin, Offset}, Queue1);
       _ ->
-        %% either the queue is empty or non-sucessive offset
+        %% either the queue is empty or non-successive offset
         queue:in({Offset, Offset}, Queue)
     end,
   handle_add_offset(PendingAcks#pending_acks{ offsets_queue = NewQueue

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -212,7 +212,8 @@ take_reqs_to_send(#buf{buffer = ?EMPTY_QUEUE} = Buf, Acc, AccBytes) ->
 take_reqs_to_send(#buf{max_batch_size = MaxBatchSize} = Buf, Acc, AccBytes)
   when AccBytes >= MaxBatchSize ->
   %% reached max bytes in one message set
-  {lists:reverse(Acc), Buf};
+  {ok, NewBuf} = maybe_buffer(Buf),
+  {lists:reverse(Acc), NewBuf};
 take_reqs_to_send(#buf{ buffer_count = BufferCount
                       , buffer       = Buffer
                       } = Buf, _Acc = [], _AccBytes = 0) ->


### PR DESCRIPTION
1. When reviewing code for issue #189, I found that we should take pending into buffer right after a batch is accumulated. i.e. Not to wait for the buffer queue to be empty.

Then added more changes to this PR including:

2. Removed `-define(EMPTY_QUEUE, {[], []}).` macro, no need for another module. This should fix issue #170 

3. Added message linger option for producer, should fix #104.

4. In my tests, single producer throughput improved from 80K to 100K when linger option is tuned, hopefully good enough to close #155 
