### PR TITLE
Make app the default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.4.0
+PROJECT_VERSION = 2.4.1
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper
@@ -35,6 +35,10 @@ ifeq ($(BROD_CLI),true)
 	ERLC_OPTS += -DBROD_CLI
 	TEST_ERLC_OPTS += -DBROD_CLI
 endif
+
+## Make app the default target
+## To avoid building a relese when brod is used as a erlang.mk project's dependency
+app::
 
 include erlang.mk
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.4.0"},
+  {vsn,"2.4.1"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_cli.erl
+++ b/src/brod_cli.erl
@@ -26,8 +26,8 @@
 
 -define(MAIN_DOC, "usage:
   brod -h|--help
-  brod -v|-version
-  brod <command> [options] [-h|--help] [--verbose | --debug]
+  brod -v|--version
+  brod <command> [options] [-h|--help] [--verbose|--debug]
 
 commands:
   meta:   Inspect topic metadata


### PR DESCRIPTION
This is to avoid building the 'release' target when brod
is used as a depencency of a erlang.mk project