### PR TITLE
Different authentication mechanisms support with plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 2.4.1
+PROJECT_VERSION = 2.5.0
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper

--- a/README.md
+++ b/README.md
@@ -352,6 +352,18 @@ brod:get_offsets(Hosts, Topic, Partition).
 brod:fetch(Hosts, Topic, Partition, 1).
 ```
 
+# Authentication support
+brod supports SASL PLAIN authentication mechanism out of the box. To use it
+add `{sasl, {plain, Username, Password}}` to client config. Also, brod has authentication
+plugins support. Authentication callback module should implement `brod_auth_backend` behavior. Auth function spec:
+```erlang
+auth(Host :: string(), Sock :: gen_tcp:socket() | ssl:sslsocket(), Mod :: atom(), ClientId :: binary(), Timeout :: pos_integer(), SaslOpts :: term()) -> ok | {error, Reason :: term()}
+```
+If authentication is successful - callback function should return an atom `ok`, otherwise - error description.
+For example, you can use brod_gssapi plugin (https://github.com/ElMaxo/brod_gssapi) for SASL GSSAPI authentication in brod.
+To use it - add it as dependency to your top level application, that uses brod and add
+`{sasl, {callback, brod_gssapi, {gssapi, Keytab, Principal}}}` to client config. Keytab and Principal should be binaries.
+
 # Self-contained binary (needs erlang runtime)
 This will build a self-contained binary with brod application
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"2.4.1"},
+  {vsn,"2.5.0"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_auth_backend.erl
+++ b/src/brod_auth_backend.erl
@@ -1,0 +1,14 @@
+-module(brod_auth_backend).
+
+-callback auth(Host :: string(), Sock :: gen_tcp:socket() | ssl:sslsocket(),
+  Mod :: atom(), ClientId :: binary(), Timeout :: pos_integer(),
+  SaslOpts :: term()) -> ok | {error, Reason :: term()}.
+
+-export([auth/7]).
+
+-spec auth(CallbackModule :: atom(), Host :: string(),
+  Sock :: gen_tcp:socket()| ssl:sslsocket(), Mod :: atom(),
+  ClientId :: binary(), Timeout :: pos_integer(),
+  SaslOpts :: term()) -> ok | {error, Reason :: term()}.
+auth(CallbackModule, Host, Sock, Mod, ClientId, Timeout, SaslOpts) ->
+  CallbackModule:auth(Host, Sock, Mod, ClientId, Timeout, SaslOpts).


### PR DESCRIPTION
As I promised, I've created SASL GSSAPI support without compile time dependencies via callback module in config