### PR TITLE
brod-cli 'commits' command use started client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.3.0
+PROJECT_VERSION = 3.3.1
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper

--- a/changelog.md
+++ b/changelog.md
@@ -56,4 +56,6 @@
   * Bug Fixes
     - Fixed brod-cli offset_fetch_request version when working with kafka 0.10.1.x or earlier
     - Make group coordinator restart on heartbeat timeout
+* 3.3.1
+  * Fix brod-cli commits command redandunt socket usage.
 

--- a/relx.config
+++ b/relx.config
@@ -8,6 +8,7 @@
  , kafka_protocol
  , jsone
  , docopt
+ , inets
  ]}.
 
 {overlay,[ {copy, "priv/ssl", ""}

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -39,3 +39,5 @@ create_topic "brod-demo-group-subscriber-loc" 3 2
 create_topic "brod_compression_SUITE"
 create_topic "test-topic"
 
+# this is to warm-up kafka group coordinator for deterministic in tests
+sudo docker exec kafka_1 /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --new-consumer --group test-group --describe > /dev/null 2>&1

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.3.0"},
+  {vsn,"3.3.1"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -646,13 +646,13 @@ connect_leader(Hosts, Topic, Partition, Options) ->
 %% @end
 -spec list_all_groups([endpoint()], sock_opts()) ->
         [{endpoint(), [cg()] | {error, any()}}].
-list_all_groups(Hosts, Options) ->
-  brod_utils:list_all_groups(Hosts, Options).
+list_all_groups(Endpoints, SockOpts) ->
+  brod_utils:list_all_groups(Endpoints, SockOpts).
 
 %% @doc List consumer groups in the given group coordinator broker.
 -spec list_groups(endpoint(), sock_opts()) -> {ok, [cg()]} | {error, any()}.
-list_groups(Hosts, Options) ->
-  brod_utils:list_groups(Hosts, Options).
+list_groups(CoordinatorEndpoint, SockOpts) ->
+  brod_utils:list_groups(CoordinatorEndpoint, SockOpts).
 
 %% @doc Describe consumer groups. The given consumer group IDs should be all
 %% managed by the coordinator-broker running at the given endpoint.
@@ -684,13 +684,13 @@ connect_group_coordinator(BootstrapEndpoints, SockOpts, GroupId) ->
 fetch_committed_offsets(BootstrapEndpoints, SockOpts, GroupId) ->
   brod_utils:fetch_committed_offsets(BootstrapEndpoints, SockOpts, GroupId, []).
 
-%% @doc Same as `fetch_committed_offsets/3', only work on the socket
-%% connected to the group coordinator broker.
+%% @doc Same as `fetch_committed_offsets/3',
+%% but works with a started `brod_client'
 %% @end
--spec fetch_committed_offsets(pid(), group_id()) ->
+-spec fetch_committed_offsets(client(), group_id()) ->
         {ok, [kpro:struct()]} | {error, any()}.
-fetch_committed_offsets(SockPid, GroupId) ->
-  brod_utils:fetch_committed_offsets(SockPid, GroupId, []).
+fetch_committed_offsets(Client, GroupId) ->
+  brod_utils:fetch_committed_offsets(Client, GroupId, []).
 
 -ifdef(BROD_CLI).
 main(Args) -> brod_cli:main(Args, halt).

--- a/src/brod_cg_commits.erl
+++ b/src/brod_cg_commits.erl
@@ -25,7 +25,6 @@
 -behaviour(brod_group_member).
 
 -export([ run/2
-        , run/3
         ]).
 
 -export([ start_link/2
@@ -76,14 +75,6 @@
         }).
 
 %%%_* APIs =====================================================================
-
-%% @doc Force commit offsets.
--spec run([brod:endpoint()], brod:client_config(), group_input()) ->
-        ok | no_return().
-run(BootstrapHosts, SockOpts, GroupInput) ->
-  ClientId = ?MODULE,
-  {ok, _} = brod_client:start_link(BootstrapHosts, ClientId, SockOpts),
-  run(ClientId, GroupInput).
 
 %% @doc Force commit offsets.
 run(ClientId, GroupInput) ->

--- a/src/brod_cg_commits.erl
+++ b/src/brod_cg_commits.erl
@@ -159,6 +159,7 @@ init({Client, GroupInput}) ->
   Config = [ {partition_assignment_strategy, callback_implemented}
            , {offset_retention_seconds, Retention}
            , {protocol_name, ProtocolName}
+           , {rejoin_delay_seconds, 2}
            ],
   {ok, Pid} = brod_group_coordinator:start_link(Client, GroupId, [Topic],
                                                 Config, ?MODULE, self()),

--- a/src/brod_cli.erl
+++ b/src/brod_cli.erl
@@ -1235,7 +1235,7 @@ parse(Args, OptName, ParseFun) ->
 print_version() ->
   _ = application:load(brod),
   {_, _, V} = lists:keyfind(brod, 1, application:loaded_applications()),
-  print(V).
+  print([V, "\n"]).
 
 %% @private
 print(IoData) -> io:put_chars(IoData).

--- a/test/brod_cli_tests.erl
+++ b/test/brod_cli_tests.erl
@@ -122,6 +122,13 @@ groups_test() ->
   assert_no_error(cmd("groups --describe")),
   assert_no_error(cmd("groups --describe --ids all")).
 
+commits_describe_test() ->
+  assert_no_error(cmd("commits --id test-group --describe")).
+
+commits_overwrite_test() ->
+  assert_no_error(cmd("commits --id test-group -t test-topic "
+                      "-o \"0:1\" -r 1d -p range")).
+
 assert_no_error(Result) ->
   case binary:match(iolist_to_binary(Result), <<"***">>) of
     nomatch -> ok;


### PR DESCRIPTION
now brod:fetch_committed_offsets/2 can be used in kastlex to support a new api to fetch committed offsets directly from kafka (instead collecting from __consumer_offsets).
