### PR TITLE
Support relative offsets in compressed batch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.3.2
+PROJECT_VERSION = 3.3.3
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ERLC_OPTS = -Werror +warn_unused_vars +warn_shadow_vars +warn_unused_import +war
 TEST_ERLC_OPTS = -Werror +warn_unused_vars +warn_shadow_vars +warn_unused_import +warn_obsolete_guard +debug_info
 
 dep_supervisor3_commit = 1.1.5
-dep_kafka_protocol_commit = 1.1.0
+dep_kafka_protocol_commit = 1.1.1
 dep_docopt = git https://github.com/zmstone/docopt-erl.git 0.1.3
 
 ERTS_VSN = $(shell erl -noshell -eval 'io:put_chars(erlang:system_info(version)), halt()')

--- a/changelog.md
+++ b/changelog.md
@@ -67,4 +67,7 @@
 * 3.3.3
   * Bug Fixes
     - Add a --no-api-vsn-query option for brod-cli to support kafka 0.9
+    - Bump kafka_protocol to 1.1.1 to fix relative offsets issue
+      so brod-cli can fetch compressed batches as expected,
+      also brod_consumer can start picking fetch request version
 

--- a/changelog.md
+++ b/changelog.md
@@ -64,4 +64,7 @@
     - Detailed log for connection estabilishment failures
   * Bug Fixes
     - Demonitor producer pid after sync_produce_request timeout
+* 3.3.3
+  * Bug Fixes
+    - Add a --no-api-vsn-query option for brod-cli to support kafka 0.9
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,12 +2,15 @@ FROM java:openjdk-8-jre
 
 ENV SCALA_VERSION 2.11
 ENV KAFKA_VERSION 0.10.2.1
+ENV KAFKA_DOWNLOAD_URL="https://apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+#ENV KAFKA_VERSION 0.9.0.0
+#ENV KAFKA_DOWNLOAD_URL="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 
 RUN apt-get update && \
     apt-get install -y zookeeper wget supervisor dnsutils && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean && \
-    wget -q http://apache.mirrors.spacedump.net/kafka/"$KAFKA_VERSION"/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
+    wget -q "${KAFKA_DOWNLOAD_URL}" -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
     tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && \
     rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
     ln -s /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION" /opt/kafka && \

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [ {supervisor3, "1.1.5"}
-       , {kafka_protocol, "1.1.0"}
+       , {kafka_protocol, "1.1.1"}
        ]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.3.2"},
+  {vsn,"3.3.3"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_cli.erl
+++ b/src/brod_cli.erl
@@ -64,6 +64,7 @@ commands:
                          password in two lines.
   --ebin-paths=<dirs>    Comma separated directory names for extra beams,
                          This is to support user compiled message formatters
+  --no-api-vsn-query     Do not query api version (for kafka 0.9 or earlier)
 "
 ).
 
@@ -372,9 +373,11 @@ main(Command, Doc, Args, Stop, LogLevel) ->
     Brokers = parse(ParsedArgs, "--brokers", fun parse_brokers/1),
     SockOpts = parse_sock_opts(ParsedArgs),
     Paths = parse(ParsedArgs, "--ebin-paths", fun parse_paths/1),
+    NoApiQuery = parse(ParsedArgs, "--no-api-vsn-query", fun parse_boolean/1),
     ok = code:add_pathsa(Paths),
     verbose("sock opts: ~p\n", [SockOpts]),
-    run(Command, Brokers, SockOpts, ParsedArgs)
+    ClientConfig = [{query_api_versions, not NoApiQuery} |  SockOpts],
+    run(Command, Brokers, ClientConfig, ParsedArgs)
   catch
     throw : Reason when is_binary(Reason) ->
       %% invalid options etc.

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -558,13 +558,13 @@ send_fetch_request(#state{ begin_offset = BeginOffset
   (is_integer(BeginOffset) andalso BeginOffset >= 0) orelse
     erlang:error({bad_begin_offset, BeginOffset}),
   Request =
-    kpro:fetch_request(_Vsn = 0, %% TODO: pick version
-                       State#state.topic,
-                       State#state.partition,
-                       State#state.begin_offset,
-                       State#state.max_wait_time,
-                       State#state.min_bytes,
-                       State#state.max_bytes),
+    brod_kafka_request:fetch_request(SocketPid,
+                                     State#state.topic,
+                                     State#state.partition,
+                                     State#state.begin_offset,
+                                     State#state.max_wait_time,
+                                     State#state.min_bytes,
+                                     State#state.max_bytes),
   brod_sock:request_async(SocketPid, Request).
 
 %% @private

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -52,14 +52,14 @@ produce_request(MaybePid, Topic, Partition, KvList,
 %% `brod_kafka_apis:pick_version/2' to resolve version.
 %%
 %% NOTE: `pick_version' is essentially a ets lookup, for intensive callers
-%%       like `brod_producer', we should pick version before hand
+%%       like `brod_producer', we should pick version beforehand
 %%       and re-use it for each produce request.
 %% @end
--spec fetch_request(pid() | vsn(), topic(), partition(), offset(),
+-spec fetch_request(pid(), topic(), partition(), offset(),
                     kpro:wait(), kpro:count(), kpro:count()) -> kpro:req().
-fetch_request(MaybePid, Topic, Partition, Offset,
+fetch_request(Pid, Topic, Partition, Offset,
               WaitTime, MinBytes, MaxBytes) ->
-  Vsn = pick_version(fetch_request, MaybePid),
+  Vsn = pick_version(fetch_request, Pid),
   kpro:fetch_request(Vsn, Topic, Partition, Offset,
                      WaitTime, MinBytes, MaxBytes).
 


### PR DESCRIPTION
The relative offset issue only affected brod-cli and brod_utils:fetch api
because version 0 was hard-coded in brod_consumer.erl
