### PR TITLE
Introduce roundrobin_v2 group protocol

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,4 +70,6 @@
     - Bump kafka_protocol to 1.1.1 to fix relative offsets issue
       so brod-cli can fetch compressed batches as expected,
       also brod_consumer can start picking fetch request version
+    - Upgrade roundrobin group protocol to roundrobin_v2 to fix offset commit incompatiblility
+      with kafka spec and monitoring tools etc. see https://github.com/klarna/brod/issues/241 for details
 

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -265,6 +265,13 @@ start_client(BootstrapEndpoints, ClientId) ->
 %%       Timeout when trying to connect to one endpoint.
 %%     request_timeout (optional, default=240000, constraint: >= 1000)
 %%       Timeout when waiting for a response, socket restart when timedout.
+%%     query_api_versions (optional, default=true)
+%%       Must be set to false to work with kafka versions prior to 0.10,
+%%       When set to 'true', brod_sock will send a query request to get
+%%       the broker supported API version ranges. When set to 'false', brod
+%%       will alway use the lowest supported API version when sending requests
+%%       to kafka. Supported API version ranges can be found in:
+%%       `brod_kafka_apis:supported_versions/1'
 %% @end
 -spec start_client([endpoint()], client_id(), client_config()) ->
                       ok | {error, any()}.

--- a/src/brod_cli.erl
+++ b/src/brod_cli.erl
@@ -573,8 +573,7 @@ resolve_offsets(Topic, Time) ->
   lists:map(
     fun(P) ->
         {ok, Offset} = resolve_offset(Topic, P, Time),
-        %% - 1 here because the consumers should start fetching from + 1
-        {P, Offset - 1}
+        {P, Offset}
     end, Partitions).
 
 %% @private

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -941,15 +941,15 @@ resolve_begin_offsets([{Topic, Partition} | Rest], CommittedOffsets,
       {_, Offset} when IsConsumerManaged ->
         %% roundrobin_v2 is only for kafka commits
         %% for consumer managed offsets, it's still acked offsets
-        %% therefore we need to +1 as begin-offset
+        %% therefore we need to +1 as begin_offset
         Offset + 1;
       {_, Offset} ->
-        %% offsets committed to kafka is already begin offset
+        %% offsets committed to kafka is already begin_offset
         %% since the introduction of 'roundrobin_v2' protocol
         Offset;
       false  ->
         %% No commit history found
-        %% Should use default begin offset in consumer config
+        %% Should use default begin_offset in consumer config
         ?undef
     end,
   Assignment =
@@ -1100,8 +1100,7 @@ is_roundrobin_v1_commit(Metadata) ->
   end.
 
 %% @private Upgrade offset from old roundrobin protocol to new.
-%% old (before roundrobin_v2) brod commits acked offsets
-%% not the next offset (begin offset) to fetch
+%% old (before roundrobin_v2) brod commits acked offsets not begin_offset
 %% @end
 -spec maybe_upgrade_from_roundrobin_v1(brod:offset(), binary()) ->
         brod:offset().

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -941,7 +941,7 @@ resolve_begin_offsets([{Topic, Partition} | Rest], CommittedOffsets,
       {_, Offset} when IsConsumerManaged ->
         %% roundrobin_v2 is only for kafka commits
         %% for consumer managed offsets, it's still acked offsets
-        %% therefor we need to +1 as begin-offset
+        %% therefore we need to +1 as begin-offset
         Offset + 1;
       {_, Offset} ->
         %% offsets committed to kafka is already begin offset

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -36,12 +36,12 @@
 
 -include("brod_int.hrl").
 
--define(PARTITION_ASSIGMENT_STRATEGY_ROUNDROBIN, roundrobin). %% default
+-define(PARTITION_ASSIGMENT_STRATEGY_ROUNDROBIN, roundrobin_v2). %% default
 
 -type protocol_name() :: string().
 -type brod_offset_commit_policy() :: commit_to_kafka_v2 % default
                                    | consumer_managed.
--type brod_partition_assignment_strategy() :: roundrobin
+-type brod_partition_assignment_strategy() :: roundrobin_v2
                                             | callback_implemented.
 -type partition_assignment_strategy() :: brod_partition_assignment_strategy().
 
@@ -159,8 +159,8 @@
 %% CbModule:  The module which implements group coordinator callbacks
 %% MemberPid: The member process pid.
 %% Config: The group coordinator configs in a proplist, possible entries:
-%%  - partition_assignment_strategy  (optional, default = roundrobin)
-%%      roundrobin (topic-sticky):
+%%  - partition_assignment_strategy  (optional, default = roundrobin_v2)
+%%      roundrobin_v2 (topic-sticky):
 %%        Take all topic-offset (sorted [{TopicName, Partition}] list)
 %%        assign one to each member in a roundrobin fashion. However only
 %%        partitions in the subscription topic list are assiged.
@@ -205,7 +205,7 @@
 %%      The default special value -1 indicates that the __consumer_offsets
 %%      topic retention policy is used.
 %%      This config is irrelevant if offset_commit_policy is consumer_managed.
-%%  - protocol_name (optional, default = roundrobin)
+%%  - protocol_name (optional, default = roundrobin_v2)
 %%      This is the protocol name used when join a group, if not given,
 %%      by default `partition_assignment_strategy' is used as the protocol name.
 %%      Setting a protocol name allows to interact with consumer group members
@@ -686,7 +686,7 @@ do_commit_offsets_(#state{ groupId                  = GroupId
       fun({{Topic, Partition}, Offset}) ->
         PartitionOffset =
           [ {partition, Partition}
-          , {offset, Offset}
+          , {offset, Offset + 1} %% +1 since roundrobin_v2 protocol
           , {metadata, Metadata}
           ],
         {Topic, PartitionOffset}
@@ -820,13 +820,13 @@ all_topics(Members) ->
 -spec get_partitions(brod:client(), brod:topic()) -> [brod:partition()].
 get_partitions(Client, Topic) ->
   Count = ?ESCALATE(brod_client:get_partitions_count(Client, Topic)),
-  lists:seq(0, Count-1).
+  lists:seq(0, Count - 1).
 
 %% @private
--spec do_assign_partitions(roundrobin, [member()],
+-spec do_assign_partitions(roundrobin_v2, [member()],
                            [{brod:topic(), brod:partition()}]) ->
                               [{member_id(), [brod:partition_assignment()]}].
-do_assign_partitions(roundrobin, Members, AllPartitions) ->
+do_assign_partitions(roundrobin_v2, Members, AllPartitions) ->
   F = fun({MemberId, M}) ->
         SubscribedTopics = M#kafka_group_member_metadata.topics,
         IsValidAssignment = fun(Topic, _Partition) ->
@@ -878,7 +878,8 @@ get_topic_assignments(#state{} = State, Assignment) ->
       end, PartitionAssignments),
   TopicPartitions = lists:append(TopicPartitions0),
   CommittedOffsets = get_committed_offsets(State, TopicPartitions),
-  resolve_begin_offsets(TopicPartitions, CommittedOffsets).
+  IsConsumerManaged = State#state.offset_commit_policy =:= consumer_managed,
+  resolve_begin_offsets(TopicPartitions, CommittedOffsets, IsConsumerManaged).
 
 %% @private Fetch committed offsets from kafka,
 %% or call the consumer callback to read committed offsets.
@@ -889,7 +890,8 @@ get_committed_offsets(#state{ offset_commit_policy = consumer_managed
                             , member_pid           = MemberPid
                             , member_module        = MemberModule
                             }, TopicPartitions) ->
-  MemberModule:get_committed_offsets(MemberPid, TopicPartitions);
+  {ok, R} = MemberModule:get_committed_offsets(MemberPid, TopicPartitions),
+  R;
 get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
                             , groupId              = GroupId
                             , sock_pid             = SockPid
@@ -911,7 +913,8 @@ get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
         lists:foldl(
           fun(PartitionOffset, Acc) ->
             Partition = kpro:find(partition, PartitionOffset),
-            Offset = kpro:find(offset, PartitionOffset),
+            Offset0 = kpro:find(offset, PartitionOffset),
+            Metadata = kpro:find(metadata, PartitionOffset),
             EC = kpro:find(error_code, PartitionOffset),
             case EC =:= ?EC_UNKNOWN_TOPIC_OR_PARTITION of
               true ->
@@ -919,6 +922,7 @@ get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
                 Acc;
               false ->
                 ?ESCALATE_EC(EC),
+                Offset = maybe_upgrade_from_roundrobin_v1(Offset0, Metadata),
                 [{{Topic, Partition}, Offset} | Acc]
             end
           end, [], PartitionOffsets)
@@ -926,29 +930,36 @@ get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
   lists:append(CommittedOffsets0).
 
 %% @private
--spec resolve_begin_offsets([TP], [{TP, brod:offset()}]) ->
+-spec resolve_begin_offsets([TP], [{TP, brod:offset()}], boolean()) ->
         brod:received_assignments()
           when TP :: {brod:topic(), brod:partition()}.
-resolve_begin_offsets([], _) -> [];
-resolve_begin_offsets([{Topic, Partition} | Rest], CommittedOffsets) ->
-  Offset =
+resolve_begin_offsets([], _CommittedOffsets, _IsConsumerManaged) -> [];
+resolve_begin_offsets([{Topic, Partition} | Rest], CommittedOffsets,
+                      IsConsumerManaged) ->
+  BeginOffset =
     case lists:keyfind({Topic, Partition}, 1, CommittedOffsets) of
-      {_, Offset_} when is_integer(Offset_) ->
-        Offset_;
+      {_, Offset} when IsConsumerManaged ->
+        %% roundrobin_v2 is only for kafka commits
+        %% for consumer managed offsets, it's still acked offsets
+        %% therefor we need to +1 as begin-offset
+        Offset + 1;
+      {_, Offset} ->
+        %% offsets committed to kafka is already begin offset
+        %% since the introduction of 'roundrobin_v2' protocol
+        Offset;
       false  ->
         %% No commit history found
+        %% Should use default begin offset in consumer config
         ?undef
     end,
-  BeginOffset = case is_integer(Offset) of
-                  true  -> Offset + 1;
-                  false -> Offset
-                end,
   Assignment =
     #brod_received_assignment{ topic        = Topic
                              , partition    = Partition
                              , begin_offset = BeginOffset
                              },
-  [Assignment | resolve_begin_offsets(Rest, CommittedOffsets)].
+  [ Assignment
+  | resolve_begin_offsets(Rest, CommittedOffsets, IsConsumerManaged)
+  ].
 
 %% @private Start a timer to send a loopback command to self() to trigger
 %% a heartbeat request to the group coordinator.
@@ -1023,7 +1034,10 @@ log(#state{ groupId  = GroupId
 
 %% @private Make metata to be committed together with offsets.
 -spec make_offset_commit_metadata() -> binary().
-make_offset_commit_metadata() -> coordinator_id().
+make_offset_commit_metadata() ->
+  %% Use a '+1/' prefix as a commit from group member which supports
+  %% roundrobin_v2 protocol
+  bin(["+1/", coordinator_id()]).
 
 %% @private Make group member's user data in join_group_request
 %%
@@ -1043,8 +1057,10 @@ user_data(Action) ->
     [ coordinator_info(Action)
     ]).
 
-coordinator_info(join) -> {<<"member_coordinator">>, self()};
-coordinator_info(assign) -> {<<"leader_coordinator">>, self()}.
+%% @private
+-spec coordinator_info(join | assign) -> {atom(), pid()}.
+coordinator_info(join) -> {member_coordinator, self()};
+coordinator_info(assign) -> {leader_coordinator, self()}.
 
 %% @private Make a client_id() to be used in the requests sent over the group
 %% coordinator's socket (group coordinator on the other end), this id will be
@@ -1063,6 +1079,38 @@ coordinator_id() ->
 -spec bin(iodata()) -> binary().
 bin(X) -> iolist_to_binary(X).
 
+%% @private Before roundrobin_v2, brod had two versions of commit metadata:
+%% 1. "ts() node() pid()"
+%%    e.g. "2017-10-24:18:20:55.475670 'nodename@host-name' <0.18980.6>"
+%% 2. "node()/pid()"
+%%    e.g. "'nodename@host-name'/<0.18980.6>"
+%% Then roundrobin_v2:
+%%    "+1/node()/pid()"
+%%    e.g. "+1/'nodename@host-name'/<0.18980.6>"
+%% Here we try to recognize brod commits using a regexp,
+%% then check the +1 prefix to exclude roundrobin_v2.
+%% @end
+-spec is_roundrobin_v1_commit(?kpro_null | binary()) -> boolean().
+is_roundrobin_v1_commit(?kpro_null) -> false;
+is_roundrobin_v1_commit(<<"+1/", _/binary>>) -> false;
+is_roundrobin_v1_commit(Metadata) ->
+  case re:run(Metadata, ".*@.*[/|\s]<0\.[0-9]+\.[0-9]+>$") of
+    nomatch -> false;
+    {match, _} -> true
+  end.
+
+%% @private Upgrade offset from old roundrobin protocol to new.
+%% old (before roundrobin_v2) brod commits acked offsets
+%% not the next offset (begin offset) to fetch
+%% @end
+-spec maybe_upgrade_from_roundrobin_v1(brod:offset(), binary()) ->
+        brod:offset().
+maybe_upgrade_from_roundrobin_v1(Offset, Metadata) ->
+  case is_roundrobin_v1_commit(Metadata) of
+    true  -> Offset + 1;
+    false -> Offset
+  end.
+
 -ifdef(TEST).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -1077,6 +1125,17 @@ merge_acked_offsets_test() ->
                merge_acked_offsets([{{<<"topic1">>, 1}, 1},
                                     {{<<"topic1">>, 2}, 1}],
                                    [{{<<"topic1">>, 1}, 2}])),
+  ok.
+
+is_roundrobin_v1_commit_test() ->
+  M1 = bin("2017-10-24:18:20:55.475670 'nodename@host-name' <0.18980.6>"),
+  M2 = bin("'nodename@host-name'/<0.18980.6>"),
+  ?assert(is_roundrobin_v1_commit(M1)),
+  ?assert(is_roundrobin_v1_commit(M2)),
+  ?assertNot(is_roundrobin_v1_commit(<<"">>)),
+  ?assertNot(is_roundrobin_v1_commit(?kpro_null)),
+  ?assertNot(is_roundrobin_v1_commit(<<"+1/not-node()-pid()">>)),
+  ?assertNot(is_roundrobin_v1_commit(make_offset_commit_metadata())),
   ok.
 
 -endif. % TEST

--- a/src/brod_group_member.erl
+++ b/src/brod_group_member.erl
@@ -47,9 +47,11 @@
 -include("brod_int.hrl").
 
 %% Call the callback module to initialize assignments.
-%% NOTE: this function is called only when 'offset_commit_policy' is
-%% 'consumer_managed' in group config.
-%% see brod_group_coordinator:start_link/6. for more group config details.
+%% NOTE: This function is called only when `offset_commit_policy' is
+%%       `consumer_managed' in group config.
+%%       see brod_group_coordinator:start_link/6. for more group config details
+%% NOTE: The committed offsets should be the offsets for successfully processed
+%%       (acknowledged) messages, not the begin-offset to start fetching from.
 -callback get_committed_offsets(pid(), [{brod:topic(), brod:partition()}]) ->
             {ok, [{{brod:topic(), brod:partition()}, brod:offset()}]}.
 

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -218,6 +218,7 @@ start_link(Client, GroupId, Topics, GroupConfig,
           ConsumerConfig, MessageType, CbModule, CbInitArg},
   gen_server:start_link(?MODULE, Args, []).
 
+%% @doc Stop group subscriber, wait for pid DOWN before return.
 -spec stop(pid()) -> ok.
 stop(Pid) ->
   Mref = erlang:monitor(process, Pid),
@@ -273,7 +274,7 @@ assign_partitions(Pid, Members, TopicPartitionList) ->
 %%       `consumer_managed' in group config.
 %%
 %% NOTE: The committed offsets should be the offsets for successfully processed
-%%       (acknowledged) messages, not the begin-offset to start fetching from.
+%%       (acknowledged) messages, not the `begin_offset' to start fetching from.
 %% @end
 -spec get_committed_offsets(pid(), [{brod:topic(), brod:partition()}]) ->
         {ok, [{{brod:topic(), brod:partition()}, brod:offset()}]}.
@@ -382,8 +383,8 @@ handle_call(unsubscribe_all_partitions, _From,
             ok
         end
     end, Consumers),
-  {reply, ok, State#state{ consumers        = []
-                         , is_blocked       = true
+  {reply, ok, State#state{ consumers  = []
+                         , is_blocked = true
                          }};
 handle_call(Call, _From, State) ->
   {reply, {error, {unknown_call, Call}}, State}.

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -144,6 +144,9 @@ start_link(Client, Topic, Partitions, ConsumerConfig,
 %% @doc Start (link) a topic subscriber which receives and processes the
 %% messages from the given partition set. Use atom 'all' to subscribe to all
 %% partitions. Messages are handled by calling the callback function.
+%%
+%% NOTE: CommittedOffsets are the offsets for the messages that are successfully
+%%       processed (acknoledged), not the begin-offset ot start fetching from.
 %% @end
 -spec start_link(brod:client(), brod:topic(), all | [brod:partition()],
                  brod:consumer_config(), committed_offsets(),


### PR DESCRIPTION
Fixes #241 

### Changes

Prior to this change, brod's 'roundrobin' group protocol commits
acknowledged offsets to kafka, then +1 as begin-offset when assign
to group members to continue after restart/rebalance.

Starting from this version, brod will commit 'next offset to fetch',
to be compliant with the protocol spec and other kafka client
implementations, as well as monitoring tools.

### Upgrade offsets committed to kafka

'roundrobin_v2' will upgrade old commits to new version by +1.
This is done by making use of the metadata committed together
with the offsets:
  'roundrobin' metadata should be a string containing the Erlang node
  name and the group coordinator pid. e.g. "myconsumer@myhost/<0,6,0>".
  'roundrogin_v2' uses the same but with a `"+1/"` prefix.

#### NOTE

Since it's a new protocol, it does not support rolling upgrade
from a running 'roundrobin' group. i.e. all 'roundrobin' members
will have to be stopped before starting 'roundrobin_v2' members.

Nonetheless, there is no risk even if 'roudrobin' and
'roundrobin_v2' members are started at the same time,
because kafka would not allow a member supporting different
protocol to join an active group.

It is however NOT OK for 'roundrobin' members to pick up
'roundrobin_v2' commits. i.e. downgrade is not supported.

### For consumer managed offsets:

For consumer managed offsets (offset_commit_policy = consumer_managed):
There is no way to smooth upgrade already committed offsets,
therefor we will keep commiting 'acked offsets' instead of 
'begin offset' until next major release.
