### PR TITLE
Revert offset=-1 handling for offset_fetch_response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.3.3
+PROJECT_VERSION = 3.3.4
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper

--- a/changelog.md
+++ b/changelog.md
@@ -65,11 +65,12 @@
   * Bug Fixes
     - Demonitor producer pid after sync_produce_request timeout
 * 3.3.3
-  * Bug Fixes
-    - Add a --no-api-vsn-query option for brod-cli to support kafka 0.9
-    - Bump kafka_protocol to 1.1.1 to fix relative offsets issue
-      so brod-cli can fetch compressed batches as expected,
-      also brod_consumer can start picking fetch request version
-    - Upgrade roundrobin group protocol to roundrobin_v2 to fix offset commit incompatiblility
-      with kafka spec and monitoring tools etc. see https://github.com/klarna/brod/issues/241 for details
-
+  * Add a --no-api-vsn-query option for brod-cli to support kafka 0.9
+  * Bump kafka_protocol to 1.1.1 to fix relative offsets issue
+    so brod-cli can fetch compressed batches as expected,
+    also brod_consumer can start picking fetch request version
+  * Upgrade roundrobin group protocol to roundrobin_v2 to fix offset commit incompatiblility
+    with kafka spec and monitoring tools etc. see https://github.com/klarna/brod/issues/241 for details
+* 3.3.4
+  * Fix issue #247 -- revert the handling of offset = -1 in offset_fetch_response, bug introduced in 3.3.0
+    offset = -1 in offset_fetch_response is an indicator of 'no commit' should be ignored (not taken as 'latest')

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.3.3"},
+  {vsn,"3.3.4"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -916,12 +916,12 @@ get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
             Offset0 = kpro:find(offset, PartitionOffset),
             Metadata = kpro:find(metadata, PartitionOffset),
             EC = kpro:find(error_code, PartitionOffset),
-            case EC =:= ?EC_UNKNOWN_TOPIC_OR_PARTITION of
+            ?ESCALATE_EC(EC),
+            %% Offset -1 in offset_fetch_response is an indicator of 'no-value'
+            case EC =:= ?EC_NONE andalso Offset0 =:= -1 of
               true ->
-                %% EC_UNKNOWN_TOPIC_OR_PARTITION is kept for version 0
                 Acc;
               false ->
-                ?ESCALATE_EC(EC),
                 Offset = maybe_upgrade_from_roundrobin_v1(Offset0, Metadata),
                 [{{Topic, Partition}, Offset} | Acc]
             end


### PR DESCRIPTION
Fixes #247 

offset=-1 is an indicator of no-commit
should not be taken as 'latest'

Also, since we no longer support offset_fetch_request version 0
the special handeling for v0 is removed