### PR TITLE
Restart subscriber from first unseen offset in case of consumer crash

### DIFF
--- a/src/brod.erl
+++ b/src/brod.erl
@@ -167,6 +167,7 @@
 
 %% consumers
 -type consumer_option() :: begin_offset
+                         | acked_offset
                          | min_bytes
                          | max_bytes
                          | max_wait_time


### PR DESCRIPTION
`brod_topic_subscriber` and `brod_group_subscriber` shall handle a crash of `brod_consumer` transparent to the user. However, they used to resubscribe from the last acked offset with the `brod_consumer` process after its restart. This is not correct, as this would lead to double delivery of messages that had been delivered, but hadn't been acked before the crash.

This change fixes this problem (see the new `t_consumer_crash` test cases that would fail without this patch), and also makes sure that after a resubscribe the prefetch window of the `brod_consumer` is reduced by the number of outstanding unacked messages. This is to prevent a rapidly crashing and restarting `brod_consumer` to flood a slow async subscriber with messages.