### PR TITLE
Fix incorrect typespec

### DIFF
--- a/src/brod.erl
+++ b/src/brod.erl
@@ -521,7 +521,7 @@ start_link_group_subscriber(Client, GroupId, Topics, GroupConfig,
 %% @equiv brod_group_subscriber:start_link/8
 -spec start_link_group_subscriber(
         client(), group_id(), [topic()], group_config(),
-        consumer_config(), message | message_type,
+        consumer_config(), message | message_set,
         module(), term()) ->
           {ok, pid()} | {error, any()}.
 start_link_group_subscriber(Client, GroupId, Topics, GroupConfig,


### PR DESCRIPTION
brod:start_link_group_subscriber/8 has an incorrect typespec.

It declares `message | message_type` for the message type, but should be `message | message_set`.
This causes dialyzer to freak out in my client apllication. 

Ideally there would be a `message_type()` type that all typespecs could refer to, but this commit at least removes the error.