### PR TITLE
resolve_offset doesn't exist anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Topic = <<"topic">>.
 Partition = 0.
 brod:get_metadata(Hosts).
 brod:get_metadata(Hosts, [Topic]).
-brod:get_offsets(Hosts, Topic, Partition).
+brod:resolve_offset(Hosts, Topic, Partition).
 brod:fetch(Hosts, Topic, Partition, 1).
 ```
 


### PR DESCRIPTION
Update the README to a function that exists. Honestly, not sure whether `brod_utils:fetch_offsets` or `brod:resolve_offset` would be right here but it's still better than a method that doesn't exist anymore.