### PR TITLE
Add new produce API call, returning the assigned offset 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.4.0
+PROJECT_VERSION = 3.5.0
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(BROD_CLI),true)
 endif
 
 ## Make app the default target
-## To avoid building a relese when brod is used as a erlang.mk project's dependency
+## To avoid building a release when brod is used as a erlang.mk project's dependency
 app::
 
 include erlang.mk

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ auth(Host :: string(), Sock :: gen_tcp:socket() | ssl:sslsocket(),
 ```
 
 If authentication is successful - callback function should return an atom `ok`, otherwise - error tuple with reason description.
-For example, you can use `brod_gssapi' plugin (https://github.com/ElMaxo/brod_gssapi) for SASL GSSAPI authentication.
+For example, you can use `brod_gssapi` plugin (https://github.com/ElMaxo/brod_gssapi) for SASL GSSAPI authentication.
 To use it - add it as dependency to your top level project that uses brod.
 Then add `{sasl, {callback, brod_gssapi, {gssapi, Keytab, Principal}}}` to client config.
 Keytab should be the keytab file path, and Principal should be a byte-list or binary string.

--- a/changelog.md
+++ b/changelog.md
@@ -80,3 +80,6 @@
 * 3.4.0
   * Add `prefetch_bytes' consumer config. `brod_consumer' should stop fetch-ahead only when
     both `prefetch_count' and `prefetch_bytes' limits are exceeded
+* 3.5.0
+  * Add `*_offset` variants to `produce` APIs, returning the base offsets that were assigned by Kafka.
+    Producers need to be restarted when upgrading to this version.

--- a/include/brod.hrl
+++ b/include/brod.hrl
@@ -44,7 +44,10 @@
                        , ref    :: reference()
                        }).
 
+-define(BROD_PRODUCE_UNKNOWN_OFFSET, -1).
+
 -record(brod_produce_reply, { call_ref :: brod:call_ref()
+                            , offset   :: brod:offset()
                             , result   :: brod:produce_result()
                             }).
 

--- a/include/brod.hrl
+++ b/include/brod.hrl
@@ -47,7 +47,7 @@
 -define(BROD_PRODUCE_UNKNOWN_OFFSET, -1).
 
 -record(brod_produce_reply, { call_ref :: brod:call_ref()
-                            , offset   :: brod:offset()
+                            , base_offset :: brod:offset()
                             , result   :: brod:produce_result()
                             }).
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.4.0"},
+  {vsn,"3.5.0"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -438,7 +438,7 @@ produce_sync(Client, Topic, Partition, Key, Value) ->
 sync_produce_request(CallRef) ->
   sync_produce_request(CallRef, infinity).
 
--spec sync_produce_request(call_ref(), infinity | timeout()) ->
+-spec sync_produce_request(call_ref(), timeout()) ->
         ok | {error, Reason :: any()}.
 sync_produce_request(CallRef, Timeout) ->
   Expect = #brod_produce_reply{ call_ref = CallRef

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -190,7 +190,7 @@ produce(Pid, Key, Value) ->
 %%      The caller pid of this function must be the caller of produce/3
 %%      in which the call reference was created.
 %% @end
--spec sync_produce_request(produce_reply(), infinity | timeout()) ->
+-spec sync_produce_request(produce_reply(), timeout()) ->
         ok | {error, {producer_down, any()}}.
 sync_produce_request(#brod_produce_reply{call_ref = CallRef} = ExpectedReply,
                      Timeout) ->

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -199,7 +199,7 @@ sync_produce_request(CallRef, Timeout) ->
   Mref = erlang:monitor(process, Callee),
   receive
     #brod_produce_reply{ call_ref = CallRef
-                       , offset   = Offset
+                       , base_offset = Offset
                        , result   = brod_produce_req_acked
                        } ->
       erlang:demonitor(Mref, [flush]),

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -149,8 +149,7 @@ ack(Buf, CorrId) ->
 ack(#buf{ onwire_count = OnWireCount
         , onwire       = [{CorrId, Reqs} | Rest]
         } = Buf, CorrId, BaseOffset) ->
-  Fold = fun(R, Offset) -> reply_acked(R, Offset) end,
-  _ = lists:foldl(Fold, BaseOffset, Reqs),
+  _ = lists:foldl(fun reply_acked/2, BaseOffset, Reqs),
   {ok, Buf#buf{ onwire_count = OnWireCount - 1
               , onwire       = Rest
               }};

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -383,7 +383,7 @@ maybe_buffer(#buf{} = Buf) ->
 -spec reply_buffered(req()) -> ok.
 reply_buffered(#req{call_ref = CallRef}) ->
   Reply = #brod_produce_reply{ call_ref = CallRef
-                             , offset   = ?BROD_PRODUCE_UNKNOWN_OFFSET
+                             , base_offset = ?BROD_PRODUCE_UNKNOWN_OFFSET
                              , result   = brod_produce_req_buffered
                              },
   cast(CallRef#brod_call_ref.caller, Reply).
@@ -395,7 +395,7 @@ reply_acked(Req) ->
 -spec reply_acked(req(), offset()) -> ok.
 reply_acked(#req{call_ref = CallRef}, Offset) ->
   Reply = #brod_produce_reply{ call_ref = CallRef
-                             , offset   = Offset
+                             , base_offset = Offset
                              , result   = brod_produce_req_acked
                              },
   cast(CallRef#brod_call_ref.caller, Reply).

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -20,6 +20,7 @@
 -export([ new/7
         , add/4
         , ack/2
+        , ack/3
         , nack/3
         , nack_all/2
         , maybe_send/3
@@ -74,6 +75,7 @@
 -opaque buf() :: #buf{}.
 
 -type corr_id() :: brod:corr_id().
+-type offset()  :: brod:offset().
 
 %%%_* APIs =====================================================================
 
@@ -137,14 +139,19 @@ maybe_send(#buf{} = Buf, SockPid, Vsn) ->
 
 %% @doc Reply 'acked' to callers.
 -spec ack(buf(), corr_id()) -> {ok, buf()} | {error, none | corr_id()}.
+ack(Buf, CorrId) ->
+  ack(Buf, CorrId, ?BROD_PRODUCE_UNKNOWN_OFFSET).
+
+-spec ack(buf(), corr_id(), offset()) ->
+             {ok, buf()} | {error, none | corr_id()}.
 ack(#buf{ onwire_count = OnWireCount
         , onwire       = [{CorrId, Reqs} | Rest]
-        } = Buf, CorrId) ->
-  ok = lists:foreach(fun reply_acked/1, Reqs),
+        } = Buf, CorrId, Offset) ->
+  ok = lists:foreach(fun(R) -> reply_acked(R, Offset) end, Reqs),
   {ok, Buf#buf{ onwire_count = OnWireCount - 1
               , onwire       = Rest
               }};
-ack(#buf{onwire = OnWire}, CorrIdReceived) ->
+ack(#buf{onwire = OnWire}, CorrIdReceived, _Offset) ->
   %% unkonwn corr-id, ignore
   CorrIdExpected = assert_corr_id(OnWire, CorrIdReceived),
   {error, CorrIdExpected}.
@@ -376,13 +383,19 @@ maybe_buffer(#buf{} = Buf) ->
 -spec reply_buffered(req()) -> ok.
 reply_buffered(#req{call_ref = CallRef}) ->
   Reply = #brod_produce_reply{ call_ref = CallRef
+                             , offset   = ?BROD_PRODUCE_UNKNOWN_OFFSET
                              , result   = brod_produce_req_buffered
                              },
   cast(CallRef#brod_call_ref.caller, Reply).
 
 -spec reply_acked(req()) -> ok.
-reply_acked(#req{call_ref = CallRef}) ->
+reply_acked(Req) ->
+  reply_acked(Req, ?BROD_PRODUCE_UNKNOWN_OFFSET).
+
+-spec reply_acked(req(), offset()) -> ok.
+reply_acked(#req{call_ref = CallRef}, Offset) ->
   Reply = #brod_produce_reply{ call_ref = CallRef
+                             , offset   = Offset
                              , result   = brod_produce_req_acked
                              },
   cast(CallRef#brod_call_ref.caller, Reply).

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -624,7 +624,7 @@ request_sync(Pid, Req) ->
   request_sync(Pid, Req, infinity).
 
 %% @private
--spec request_sync(pid(), kpro:req(), infinity | timeout()) -> kpro:rsp().
+-spec request_sync(pid(), kpro:req(), timeout()) -> kpro:rsp().
 request_sync(Pid, Req, Timeout) ->
   % brod_sock has a global 'request_timeout' option
   % the socket pid will exit if that one times out

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -47,7 +47,6 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include("brod.hrl").
 -include("brod_int.hrl").
 
 -define(HOSTS, [{"localhost", 9092}]).

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -177,7 +177,6 @@ t_produce_no_ack({init, Config}) ->
   ok = brod:start_consumer(Client, Topic, []),
   Subscriber = spawn_link(fun() -> subscriber_loop(Client, TesterPid) end),
   {ok, _ConsumerPid1} = brod:subscribe(Client, Subscriber, Topic, 0, []),
-  {ok, _ConsumerPid2} = brod:subscribe(Client, Subscriber, Topic, 1, []),
   [{client, Client}, {client_pid, ClientPid},
    {subscriber, Subscriber} | Config];
 t_produce_no_ack(Config) when is_list(Config) ->

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -46,6 +46,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("brod.hrl").
 -include("brod_int.hrl").
 
 -define(HOSTS, [{"localhost", 9092}]).
@@ -222,8 +223,8 @@ t_produce_no_ack_offset(Config) when is_list(Config) ->
     end,
   ReceiveFun(K1, V1),
   ReceiveFun(K2, V2),
-  ?assert(?IS_SPECIAL_OFFSET(O1)),
-  ?assert(?IS_SPECIAL_OFFSET(O2)).
+  ?assert(O1 =:= ?BROD_PRODUCE_UNKNOWN_OFFSET),
+  ?assert(O2 =:= ?BROD_PRODUCE_UNKNOWN_OFFSET).
 
 t_produce_async(Config) when is_list(Config) ->
   Client = ?config(client),


### PR DESCRIPTION
Kafka responses for produce requests that are acknowledged include the offset that was assigned to the message. This PR adds an API call for retrieving this offset. 

It also includes a number of small fixes.

Feedback is very welcome. :-)