### PR TITLE
Check high-watermark offset when receiving an empty batch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.5.1
+PROJECT_VERSION = 3.5.2
 
 DEPS = supervisor3 kafka_protocol
 TEST_DEPS = docopt jsone meck proper

--- a/changelog.md
+++ b/changelog.md
@@ -86,4 +86,6 @@
 * 3.5.1
   * Add `extra_sock_opts` client socket options.
     It would be helpful for tuning the performance of tcp socket.
-    
+* 3.5.2
+  * Fix issue #263: Kafka 0.11 may send empty batch in fetch response when messages are deleted in
+    compacted topics.

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.5.1"},
+  {vsn,"3.5.2"},
   {registered,[]},
   {applications,[kernel,stdlib,ssl,kafka_protocol,supervisor3]},
   {env,[]},


### PR DESCRIPTION
fixes #263 
In case RequestOffset < HighWatermarkOffset, bump to RequestOffset + 1
and try again
