### PR TITLE
Add bord:produce_cb API.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TEST_ERLC_OPTS = $(COMMON_ERLC_OPTS)
 
 
 dep_supervisor3_commit = 1.1.5
-dep_kafka_protocol_commit = 2.0.0
+dep_kafka_protocol_commit = 2.0.1
 dep_kafka_protocol = git https://github.com/klarna/kafka_protocol.git $(dep_kafka_protocol_commit)
 dep_docopt = git https://github.com/zmstone/docopt-erl.git 0.1.3
 

--- a/README.md
+++ b/README.md
@@ -58,35 +58,26 @@ with some non-important printouts trimmed.
 > rr(brod).
 > {ok, _} = application:ensure_all_started(brod).
 > KafkaBootstrapEndpoints = [{"localhost", 9092}].
-> Topic = <<"brod-test">>.
+> Topic = <<"test-topic">>.
 > Partition = 0.
 > ok = brod:start_client(KafkaBootstrapEndpoints, client1).
 > ok = brod:start_producer(client1, Topic, _ProducerConfig = []).
 > ok = brod:produce_sync(client1, Topic, Partition, <<"key1">>, <<"value1">>).
 > ok = brod:produce_sync(client1, Topic, Partition, <<"key2">>, <<"value2">>).
-> SubscriberCallbackFun =
-    fun(Partition, Msg, ShellPid = CallbackState) ->
-      ShellPid ! Msg,
-      {ok, ack, CallbackState}
-    end.
+> SubscriberCallbackFun = fun(Partition, Msg, ShellPid = CallbackState) -> ShellPid ! Msg, {ok, ack, CallbackState} end.
 > Receive = fun() -> receive Msg -> Msg after 1000 -> timeout end end.
 > brod_topic_subscriber:start_link(client1, Topic, Partitions=[Partition],
                                    _ConsumerConfig=[{begin_offset, earliest}],
                                    _CommittdOffsets=[], message, SubscriberCallbackFun,
                                    _CallbackState=self()).
 > Receive().
-#kafka_message{offset = 0,magic_byte = 0,attributes = 0,
-               key = <<"key1">>,value = <<"value1">>,crc = 1978725405}
+#kafka_message{offset = 0,magic_byte = 0,attributes = 0, key = <<"key1">>,value = <<"value1">>,crc = 1978725405}
 > Receive().
-#kafka_message{offset = 1,magic_byte = 0,attributes = 0,
-               key = <<"key2">>,value = <<"value2">>,crc = 1964753830}
-> {ok, CallRef} = brod:produce(client1, Topic, Partition, <<"key3">>, <<"value3">>).
-> #brod_produce_reply{ call_ref = CallRef,
-                       result   = brod_produce_req_acked
-                     } = Receive().
+#kafka_message{offset = 1,magic_byte = 0,attributes = 0, key = <<"key2">>,value = <<"value2">>,crc = 1964753830}
+> AckCb = fun(Partition, BaseOffset) -> io:format(user, "batch produced to partition ~p at base-offset ~p\n", [Partition, BaseOffset]) end,
+> ok = brod:produce_cb(client1, Topic, Partition, <<>>, [{<<"key3">>, <<"value3">>}], AckCb).
 > Receive().
-#kafka_message{offset = 2,magic_byte = 0,attributes = 0,
-               key = <<"key3">>,value = <<"value3">>,crc = -1013830416}
+#kafka_message{offset = 2,magic_byte = 0,attributes = 0, key = <<"key3">>,value = <<"value3">>,crc = -1013830416}
 ```
 
 # Overview

--- a/changelog.md
+++ b/changelog.md
@@ -102,5 +102,5 @@
   * There is no more cool-down delay for metadata socket re-establishment
   * `brod_group_coordinator` default session timeout changed from 10 seconds to 30,
      and heartbeat interval changed from 2 seconds to 5.
-  * Add `brod:produce_cb/4` and `brod:porduce_cb/6` to support user devined callback for
-    produce ack handler.
+  * Add `brod:produce_cb/4` and `brod:porduce_cb/6` to support user devined callback for produce ack handler.
+  * Add `brod:produce_no_ack/3` and `brod:produce_no_ack/5`

--- a/changelog.md
+++ b/changelog.md
@@ -102,3 +102,5 @@
   * There is no more cool-down delay for metadata socket re-establishment
   * `brod_group_coordinator` default session timeout changed from 10 seconds to 30,
      and heartbeat interval changed from 2 seconds to 5.
+  * Add `brod:produce_cb/4` and `brod:porduce_cb/6` to support user devined callback for
+    produce ack handler.

--- a/include/brod.hrl
+++ b/include/brod.hrl
@@ -39,15 +39,15 @@
         , error_desc = ""
         }).
 
--record(brod_call_ref, { caller :: pid()
-                       , callee :: pid()
-                       , ref    :: reference()
+-record(brod_call_ref, { caller :: undefined | pid()
+                       , callee :: undefined | pid()
+                       , ref    :: undefined | reference()
                        }).
 
 -define(BROD_PRODUCE_UNKNOWN_OFFSET, -1).
 
 -record(brod_produce_reply, { call_ref :: brod:call_ref()
-                            , base_offset :: brod:offset()
+                            , base_offset :: undefined | brod:offset()
                             , result   :: brod:produce_result()
                             }).
 

--- a/include/brod_int.hrl
+++ b/include/brod_int.hrl
@@ -48,6 +48,9 @@
 -define(KV(Key, Value), {Key, Value}).
 -define(TKV(Ts, Key, Value), {Ts, Key, Value}).
 
+-define(acked, brod_produce_req_acked).
+-define(buffered, brod_produce_req_buffered).
+
 -endif. % include brod_int.hrl
 
 %%%_* Emacs ====================================================================

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [ {supervisor3, "1.1.5"}
-       , {kafka_protocol, "2.0.0"}
+       , {kafka_protocol, "2.0.1"}
        ]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -38,7 +38,7 @@
 -type milli_ts() :: pos_integer().
 -type milli_sec() :: non_neg_integer().
 -type count() :: non_neg_integer().
--type cb() :: fun((buffered | {acked, offset()}) -> ok).
+-type cb() :: fun((?buffered | {?acked, offset()}) -> ok).
 
 -record(req,
         { cb       :: cb()

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -36,6 +36,7 @@
         , t_producer_partition_not_found/1
         , t_produce_partitioner/1
         , t_produce_batch/1
+        , t_produce_batch_callback/1
         , t_produce_buffered_offset/1
         ]).
 
@@ -287,6 +288,40 @@ t_produce_batch(Config) when is_list(Config) ->
   {K3, V3} = make_unique_kv(),
   Batch = [{K1, V1}, {K2, V2}, {<<>>, [{K3, V3}]}],
   ok = brod:produce_sync(Client, ?TOPIC, Partition, undefined, Batch),
+  ReceiveFun =
+    fun(ExpectedK, ExpectedV) ->
+      receive
+        {_, _, K, V} ->
+          ?assertEqual(ExpectedK, K),
+          ?assertEqual(ExpectedV, V)
+        after 5000 ->
+          ct:fail({?MODULE, ?LINE, timeout, ExpectedK, ExpectedV})
+      end
+    end,
+  ReceiveFun(K1, V1),
+  ReceiveFun(K2, V2),
+  ReceiveFun(K3, V3).
+
+t_produce_batch_callback(Config) when is_list(Config) ->
+  Client = ?config(client),
+  Partition = 0,
+  {K1, V1} = make_unique_kv(),
+  {K2, V2} = make_unique_kv(),
+  {K3, V3} = make_unique_kv(),
+  Batch = [{K1, V1}, {K2, V2}, {<<>>, [{K3, V3}]}],
+  Self = self(),
+  Ref = make_ref(),
+  Cb = fun(_Partition, _Offset) ->
+           Self ! {Ref, kafka_acked}
+       end,
+  ok = brod:produce_cb(Client, ?TOPIC, Partition, undefined, Batch, Cb),
+  receive
+    {Ref, kafka_acked} ->
+      ok
+  after
+    5000 ->
+      ct:fail({?MODULE, ?LINE, timeout})
+  end,
   ReceiveFun =
     fun(ExpectedK, ExpectedV) ->
       receive

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -38,6 +38,7 @@
         , t_produce_batch/1
         , t_produce_batch_callback/1
         , t_produce_buffered_offset/1
+        , t_produce_fire_n_forget/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -279,6 +280,30 @@ t_produce_partitioner(Config) when is_list(Config) ->
   ReceiveFun(0, K1, V1),
   ok = brod:produce_sync(Client, ?TOPIC, PartFun, K2, V2),
   ReceiveFun(1, K2, V2).
+
+t_produce_fire_n_forget(Config) when is_list(Config) ->
+  Client = ?config(client),
+  Partition = 0,
+  {K1, V1} = make_unique_kv(),
+  {K2, V2} = make_unique_kv(),
+  {K3, V3} = make_unique_kv(),
+  Batch = [{K1, V1}, {K2, V2}, {<<>>, [{K3, V3}]}],
+  ok = brod:produce_no_ack(Client, ?TOPIC, Partition, <<>>, Batch),
+  ReceiveFun =
+    fun(ExpectedK, ExpectedV) ->
+      receive
+        {_, _, K, V} ->
+          ?assertEqual(ExpectedK, K),
+          ?assertEqual(ExpectedV, V);
+        Msg ->
+          ct:fail({unexpected_message, Msg})
+        after 5000 ->
+          ct:fail({?MODULE, ?LINE, timeout, ExpectedK, ExpectedV})
+      end
+    end,
+  ReceiveFun(K1, V1),
+  ReceiveFun(K2, V2),
+  ReceiveFun(K3, V3).
 
 t_produce_batch(Config) when is_list(Config) ->
   Client = ?config(client),


### PR DESCRIPTION
Fixes #153 
This is to support user defined callback when produce response is received from kafka
The producer process evaluates a callback instead of sending an ack message back to the caller.