### PR TITLE
Allows a topic subscriber to start reading a partition from offset 0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -111,4 +111,7 @@
 * 3.6.1
   * Make produce request version configurable as `produce_req_vsn` in `brod:producer_config()`
   * Upgrade `kafka_protocol` to `2.1.2` to support alpine/busybox build
+* 3.6.2
+  * Allow `brod_topic_subscriber` to explicitly start consuming from partition offset 0 (by passing in
+    a committed offset of -1).
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.6.1"},
+  {vsn,"3.6.2"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -315,8 +315,9 @@ subscribe_partition(Client, Topic, Consumer) ->
             %% the default or configured 'begin_offset' will be used
             [];
           false ->
-            AckedOffset >= 0 orelse erlang:error({invalid_offset, AckedOffset}),
-            [{begin_offset, AckedOffset + 1}]
+            StartOffset = AckedOffset + 1,
+            StartOffset >= 0 orelse erlang:error({invalid_offset, AckedOffset}),
+            [{begin_offset, StartOffset}]
         end,
       case brod:subscribe(Client, self(), Topic, Partition, Options) of
         {ok, ConsumerPid} ->


### PR DESCRIPTION
by allowing the client to pass in an offset of -1. This seems like the
only reasonable way to maintain the old API while allowing the full
breadth of starting offset values.

I hit this case today while testing my application that makes use of compacted topics. On a restart of our `brod_topic_subscriber` process, it successfully re-subscribes to the brod consumer, but didn't re-start consuming from the beginning with `ConsumerConfig = [{begin_offset, earliest}]`. It appears that we have to return `{ok, [{PartitionId, EarliestOffset - 1}], State}` from our `init` to start re-consuming from where we left off. This works nicely…_except_ when the earliest offset is actually 0!

Gross as it is, this shouldn't break dialyzer as kpro:offset seems to be
a signed int.

This seems slightly related to klarna/brod#261, but at the "starting" end of things.