### PR TITLE
New API for asynchronous offset commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KAFKA_VERSION ?= 1.1
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.6.2
+PROJECT_VERSION = 3.7.0
 
 DEPS = supervisor3 kafka_protocol
 

--- a/changelog.md
+++ b/changelog.md
@@ -114,4 +114,6 @@
 * 3.6.2
   * Allow `brod_topic_subscriber` to explicitly start consuming from partition offset 0 (by passing in
     a committed offset of -1).
-
+* 3.7.0
+  * Add `brod_group_subscriber:ack/5` and `brod_group_subscriber:commit/4` to let group subscribers
+    commit offsets asynchronously

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -49,6 +49,7 @@ create_topic "brod_topic_subscriber_SUITE"    3 2
 create_topic "brod-group-subscriber-1"        3 2
 create_topic "brod-group-subscriber-2"        3 2
 create_topic "brod-group-subscriber-3"        3 2
+create_topic "brod-group-subscriber-4"
 create_topic "brod-demo-topic-subscriber"     3 2
 create_topic "brod-demo-group-subscriber-koc" 3 2
 create_topic "brod-demo-group-subscriber-loc" 3 2
@@ -63,4 +64,3 @@ sudo docker exec kafka-1 /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-ser
 if [[ "$KAFKA_VERSION" != 0.9* ]] && [[ "$KAFKA_VERSION" != 0.10* ]]; then
   sudo docker exec kafka-1 /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[iterations=8192,password=ecila],SCRAM-SHA-512=[password=ecila]' --entity-type users --entity-name alice
 fi
-

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.6.2"},
+  {vsn,"3.7.0"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},


### PR DESCRIPTION
This new API allows to ack and commit offsets independently.

Rationale: subscribers may want to implement their own buffering logic independent from brod, while still benefiting from brod's group offset management and load balancing. With the current approach it's troublesome: brod consumer message buffer should be made very large, leading to all kinds of problems.

There's a known quirk in the current PR, though: when group_subscriber is started with begin_offset=latest and restarts before committing anything, it will be restarted from the latest offset. Probably it's not the most obvious behavior, though formally correct