### PR TITLE
Handles the case where a message set contains no useful messages.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -117,3 +117,5 @@
 * 3.7.0
   * Add `brod_group_subscriber:ack/5` and `brod_group_subscriber:commit/4` to let group subscribers
     commit offsets asynchronously
+  * Fix issue #384: In compacted topics, Kafka may return a MessageSet which contains only
+    messages before the desired offset. Just keep reading forward in this case.

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -396,21 +396,30 @@ handle_batches(Header, Batches,
                      , partition    = Partition
                      } = State0) ->
   HighWmOffset = kpro:find(high_watermark, Header),
-  Messages = brod_utils:flatten_batches(BeginOffset, Batches),
-  MsgSet = #kafka_message_set{ topic          = Topic
-                             , partition      = Partition
-                             , high_wm_offset = HighWmOffset
-                             , messages       = Messages
-                             },
-  ok = cast_to_subscriber(Subscriber, MsgSet),
-  NewPendingAcks = add_pending_acks(PendingAcks, Messages),
-  {value, ?PENDING(LastOffset, _LastMsgSize)} =
-    queue:peek_r(NewPendingAcks#pending_acks.queue),
-  State1 = State0#state{ pending_acks = NewPendingAcks
-                       , begin_offset = LastOffset + 1
-                       },
-  State2 = maybe_shrink_max_bytes(State1, MsgSet#kafka_message_set.messages),
-  State = maybe_send_fetch_request(State2),
+  State1 = case brod_utils:flatten_batches(BeginOffset, Batches) of
+    [] ->
+      %% flatten_batches might remove all actual messages
+      %% (if they were all before BeginOffset), leaving us
+      %% with nothing in this batch.  Since there is no way
+      %% to know how big the 'hole' is we can only bump
+      %% begin_offset with +1 and try again.
+      State0#state{ begin_offset = BeginOffset + 1 };
+    Messages ->
+      MsgSet = #kafka_message_set{ topic          = Topic
+                                 , partition      = Partition
+                                 , high_wm_offset = HighWmOffset
+                                 , messages       = Messages
+                                 },
+      ok = cast_to_subscriber(Subscriber, MsgSet),
+      NewPendingAcks = add_pending_acks(PendingAcks, Messages),
+      {value, ?PENDING(LastOffset, _LastMsgSize)} =
+        queue:peek_r(NewPendingAcks#pending_acks.queue),
+      State2 = State0#state{ pending_acks = NewPendingAcks
+                           , begin_offset = LastOffset + 1
+                           },
+      maybe_shrink_max_bytes(State2, MsgSet#kafka_message_set.messages)
+  end,
+  State = maybe_send_fetch_request(State1),
   {noreply, State}.
 
 %% Add received offsets to pending queue.


### PR DESCRIPTION
This seems related to #275 and deals with additional effects of compacted topics.

In `brod_consumer`'s `handle_batches`, it calls `flatten_batches` which coalesces messages in a list of message sets and then filters out any messages with offests smaller than the originally requested offset. This can result in an empty message set—and if there are no other unacked
offsets for the consumer—a crash.

I've tested this empirically in our test environment (1abff7c72b45b6bb6ed38754d6152eb5c4642374 vs 9bb6717ffc36dd63eb2f20db21c8cad1cefec53c) and it seems to work. :)