### PR TITLE
Fix topic/group subscriber re-subscribe begin_offset

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -121,3 +121,6 @@
     messages before the desired offset. Just keep reading forward in this case.
   * Issue #285 `brod_consumer` no longer restart on `leader_not_availble` and `not_leader_for_partition`
     error codes received in fetch response. It resets connection and rediscover leader after delay.
+* 3.7.1
+  * Fix brod_topic_subscriber and brod_group_subscriber re-subscribe behaviour
+    to avoid fetching duplicated messages.

--- a/changelog.md
+++ b/changelog.md
@@ -124,3 +124,4 @@
 * 3.7.1
   * Fix brod_topic_subscriber and brod_group_subscriber re-subscribe behaviour
     to avoid fetching duplicated messages.
+  * Add 'random' and 'hash' partitioner for produce APIs

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -558,11 +558,9 @@ handle_ack(AckRef, #state{ generationId = GenerationId
       State
   end.
 
-%% Tell consumer process to fetch more (if pre-fetch count allows).
-consume_ack(Pid, Offset) when is_pid(Pid) ->
-  ok = brod:consume_ack(Pid, Offset);
-consume_ack(_Down, _Offset) ->
-  %% consumer is down, should be restarted by its supervisor
+%% Tell consumer process to fetch more (if pre-fetch count/byte limit allows).
+consume_ack(Pid, Offset) ->
+  is_pid(Pid) andalso brod:consume_ack(Pid, Offset),
   ok.
 
 %% Send an async message to group coordinator for offset commit.

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -40,6 +40,7 @@
         , t_produce_buffered_offset/1
         , t_produce_fire_n_forget/1
         , t_configure_produce_api_vsn/1
+        , t_produce_pre_defined_partitioner/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -286,6 +287,13 @@ t_produce_partitioner(Config) when is_list(Config) ->
   ReceiveFun(0, K1, V1),
   ok = brod:produce_sync(Client, ?TOPIC, PartFun, K2, V2),
   ReceiveFun(1, K2, V2).
+
+t_produce_pre_defined_partitioner(Config) when is_list(Config) ->
+  Client = ?config(client),
+  {K1, V1} = make_unique_kv(),
+  {K2, V2} = make_unique_kv(),
+  ok = brod:produce_sync(Client, ?TOPIC, random, K1, V1),
+  ok = brod:produce_sync(Client, ?TOPIC, hash, K2, V2).
 
 t_produce_fire_n_forget(Config) when is_list(Config) ->
   Client = ?config(client),

--- a/test/brod_topic_subscriber_SUITE.erl
+++ b/test/brod_topic_subscriber_SUITE.erl
@@ -35,6 +35,7 @@
 -export([ t_async_acks/1
         , t_demo/1
         , t_demo_message_set/1
+        , t_consumer_crash/1
         ]).
 
 
@@ -84,27 +85,24 @@ all() -> [F || {F, _A} <- module_info(exports),
 -record(state, { ct_case_ref
                , ct_case_pid
                , is_async_ack
-               , my_id
                }).
 
-init(_Topic, {CaseRef, SubscriberId, CasePid, IsAsyncAck}) ->
+init(_Topic, {CaseRef, CasePid, IsAsyncAck}) ->
   State = #state{ ct_case_ref  = CaseRef
                 , ct_case_pid  = CasePid
                 , is_async_ack = IsAsyncAck
-                , my_id        = SubscriberId
                 },
   {ok, [], State}.
 
 handle_message(Partition, Message, #state{ ct_case_ref  = Ref
                                          , ct_case_pid  = Pid
                                          , is_async_ack = IsAsyncAck
-                                         , my_id        = MyId
                                          } = State) ->
   #kafka_message{ offset = Offset
                 , value  = Value
                 } = Message,
   %% forward the message to ct case for verification.
-  Pid ! {Ref, MyId, Partition, Offset, Value},
+  Pid ! {Ref, Partition, Offset, Value},
   case IsAsyncAck of
     true  -> {ok, State};
     false -> {ok, ack, State}
@@ -157,30 +155,29 @@ t_async_acks(Config) when is_list(Config) ->
                    , {sleep_timeout, 0}
                    , {max_wait_time, 1000}
                    ],
-  CaseRef        = t_async_acks,
-  CasePid        = self(),
-  InitArgs       = {CaseRef, _SubscriberId = 0, CasePid, _IsAsyncAck = true},
-  Partition      = 0,
+  CaseRef = t_async_acks,
+  CasePid = self(),
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true},
+  Partition = 0,
   {ok, SubscriberPid} =
     brod:start_link_topic_subscriber(?CLIENT_ID, ?TOPIC, ConsumerConfig,
                                      ?MODULE, InitArgs),
   SendFun =
     fun(I) ->
-      Value = list_to_binary(integer_to_list(I)),
+      Value = integer_to_binary(I),
       ok = brod:produce_sync(?CLIENT_ID, ?TOPIC, Partition, <<>>, Value)
     end,
   RecvFun =
-    fun(Timeout, {ContinueFun, Acc}) ->
+    fun F(Timeout, Acc) ->
       receive
-        {CaseRef, 0, 0, Offset, Value} ->
+        {CaseRef, Partition, Offset, Value} ->
           ok = brod_topic_subscriber:ack(SubscriberPid, Partition, Offset),
-          I = binary_to_list(Value),
-          NewAcc = [list_to_integer(I) | Acc],
-          ContinueFun(0, {ContinueFun, NewAcc});
+          I = binary_to_integer(Value),
+          F(0, [I | Acc]);
         Msg ->
           erlang:error({unexpected_msg, Msg})
       after Timeout ->
-        {ContinueFun, Acc}
+        Acc
       end
     end,
   ok = SendFun(0),
@@ -188,15 +185,76 @@ t_async_acks(Config) when is_list(Config) ->
   %% it may or may not receive the first message (0) depending on when
   %% the consumers starts polling --- before or after the first message
   %% is produced.
-  _ = RecvFun(2000, {RecvFun, []}),
+  _ = RecvFun(2000, []),
   L = lists:seq(1, MaxSeqNo),
   ok = lists:foreach(SendFun, L),
-  %% worst case scenario, the receive loop will cost (1000 * 5 + 5 * 1000) ms
+  %% worst case scenario, the receive loop will cost (100 * 5 + 5 * 1000) ms
   Timeouts = lists:duplicate(MaxSeqNo, 5) ++ lists:duplicate(5, 1000),
-  {_, ReceivedL} = lists:foldl(RecvFun, {RecvFun, []}, Timeouts ++ [1,2,3,4,5]),
+  ReceivedL = lists:foldl(RecvFun, [], Timeouts ++ [1,2,3,4,5]),
   ?assertEqual(L, lists:reverse(ReceivedL)),
   ok = brod_topic_subscriber:stop(SubscriberPid),
   ok.
+
+t_consumer_crash(Config) when is_list(Config) ->
+  ConsumerConfig = [ {prefetch_count, 10}
+                   , {sleep_timeout, 0}
+                   , {max_wait_time, 1000}
+                   , {partition_restart_delay_seconds, 1}
+                   ],
+  CaseRef = t_consumer_crash,
+  CasePid = self(),
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true},
+  Partition = 0,
+  {ok, SubscriberPid} =
+    brod:start_link_topic_subscriber(?CLIENT_ID, ?TOPIC, ConsumerConfig,
+                                     ?MODULE, InitArgs),
+  SendFun =
+    fun(I) ->
+        ok = brod:produce_sync(?CLIENT_ID, ?TOPIC, Partition, <<>>, <<I>>)
+    end,
+  ReceiveFun =
+    fun F(MaxI, Acc) ->
+        receive
+          {CaseRef, Partition, Offset, <<MaxI>>} ->
+            lists:unzip(lists:reverse([{Offset, MaxI} | Acc]));
+          {CaseRef, Partition, Offset, <<I>>} when I < MaxI ->
+            F(MaxI, [{Offset, I} | Acc]);
+          Msg ->
+            ct:fail("Unexpected msg: ~p", [Msg])
+        after 5000 ->
+            lists:unzip(lists:reverse(Acc))
+        end
+    end,
+  SendFun(0),
+  %% the first message may or may not be received depending on when
+  %% the consumer starts polling
+  ReceiveFun(0, []),
+  %% send and receive some messages, ack some of them
+  [SendFun(I) || I <- lists:seq(1, 5)],
+  {[_, _, O3, _, O5], [1, 2, 3, 4, 5]} = ReceiveFun(5, []),
+  ok = brod_topic_subscriber:ack(SubscriberPid, Partition, O3),
+  %% do a sync request to the subscriber, so that we know it has
+  %% processed the ack, then kill the brod_consumer process
+  sys:get_state(SubscriberPid),
+  {ok, ConsumerPid} = brod:get_consumer(?CLIENT_ID, ?TOPIC, Partition),
+  Mon = monitor(process, ConsumerPid),
+  exit(ConsumerPid, test_consumer_restart),
+  receive {'DOWN', Mon, process, ConsumerPid, test_consumer_restart} -> ok
+  after 1000 -> ct:fail("timed out waiting for the consumer process to die")
+  end,
+  %% ack all previously received messages
+  %% so topic subscriber can re-subscribe to the restarted consumer
+  ok = brod_topic_subscriber:ack(SubscriberPid, Partition, O5),
+  %% send and receive some more messages, check each message arrives only once
+  [SendFun(I) || I <- lists:seq(6, 8)],
+  {_, [6, 7, 8]} = ReceiveFun(8, []),
+  %% stop the subscriber and check there are no more late messages delivered
+  ok = brod_topic_subscriber:stop(SubscriberPid),
+  receive
+    {CaseRef, Partition, Offset, Value} ->
+      ct:fail("Unexpected msg: offset ~p, value ~p", [Offset, Value])
+  after 0 -> ok
+  end.
 
 %%%_* Help funtions ============================================================
 


### PR DESCRIPTION
Prior to this change, in case of brod_consumer restart.
Topic/Group subscribers use last-acked-offset + 1
as begin-offset to start fetching messages.

This behavior resulted in re-deliveries of the messages fetched before
restart but not yet acked by message handler (async ack).

In this change, `last_offset` is added to track each partition's
progress, then only re-subscribe when ack_offset = last_offset
i.e. all previouly fetched messages are acked.