### PR TITLE
Allow brod_group_subscriber:assign_partitions/3 to update #state.cb_s…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -125,3 +125,4 @@
   * Fix brod_topic_subscriber and brod_group_subscriber re-subscribe behaviour
     to avoid fetching duplicated messages.
   * Add 'random' and 'hash' partitioner for produce APIs
+  * Allow `brod_group_subscrber:assign_partitions/3` to return an updated cb_state


### PR DESCRIPTION
Allow brod_group_subscriber:assign_partitions/3 to update #state.cb_state. 

The reason for this being that this callback can be used to handle Leader election switches between different nodes. There may be a scenario where my cb_state has to be cleared. Implementation is backwards compatible :+1: 

