### PR TITLE
Use 'begin_offset' from consumer config in brod_group_subscriber

### DIFF
--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -579,7 +579,10 @@ subscribe_partitions(#state{ client    = Client
                            , consumer_config = ConsumerConfig
                            } = State) ->
   Consumers =
-    lists:map(fun(C) -> subscribe_partition(Client, C, ConsumerConfig) end, Consumers0),
+    lists:map(
+      fun(C) ->
+        subscribe_partition(Client, C, ConsumerConfig)
+      end, Consumers0),
   {ok, State#state{consumers = Consumers}}.
 
 subscribe_partition(Client, Consumer, ConsumerConfig) ->
@@ -605,7 +608,8 @@ subscribe_partition(Client, Consumer, ConsumerConfig) ->
                       ?undef        -> BeginOffset0;
                       N when N >= 0 -> N + 1
                     end,
-      BeginOffsetFromConfig = proplists:get_value(begin_offset, ConsumerConfig, ?undef),
+      BeginOffsetFromConfig =
+          proplists:get_value(begin_offset, ConsumerConfig, ?undef),
       Options =
         if BeginOffsetFromConfig =/= ?undef ->
           [{begin_offset, BeginOffsetFromConfig}];

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -444,7 +444,6 @@ t_async_commit(Config) when is_list(Config) ->
     fun() ->
         GroupConfig = [],
         ConsumerConfig = [ {sleep_timeout, 0}
-                         , {begin_offset, latest}
                          , {prefetch_bytes, 0}
                          , {sleep_timeout, 0}
                          , {max_wait_time, 100}


### PR DESCRIPTION
When brod_group_subscriber is started with `ConsumerConfig = [{begin_offset, N}]` then this configuration option has no effect if any offset is committed to Kafka topic. In such case consumer will always be started from the last committed offset.
If consumer provides `{begin_offset, N}` configuration option then this value should be used as beginning offset.