### PR TITLE
Causes a connection reset when unknown_topic_or_partition error happens.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KAFKA_VERSION ?= 1.1
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.7.1
+PROJECT_VERSION = 3.7.2
 
 DEPS = supervisor3 kafka_protocol
 

--- a/changelog.md
+++ b/changelog.md
@@ -129,3 +129,6 @@
   * `brod_client:get_connection` is back
   * Make it possible to run tests on both mac and linux
   * Position group leader member at the head of members list when assigning partitions
+* 3.7.2
+  * Pr #298: Subscriber now automatically reconnects to Kafka on topic rebalances where
+    the previous partition leader no longer holds the partition at all.

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.7.1"},
+  {vsn,"3.7.2"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -474,11 +474,11 @@ update_avg_size(#state{ avg_bytes        = AvgBytes
   update_avg_size(State#state{avg_bytes = NewAvgBytes}, Rest).
 
 err_op(?request_timed_out)          -> retry;
-err_op(?unknown_topic_or_partition) -> stop;
 err_op(?invalid_topic_exception)    -> stop;
 err_op(?offset_out_of_range)        -> reset_offset;
 err_op(?leader_not_available)       -> reset_connection;
 err_op(?not_leader_for_partition)   -> reset_connection;
+err_op(?unknown_topic_or_partition) -> reset_connection;
 err_op(_)                           -> restart.
 
 handle_fetch_error(#kafka_fetch_error{error_code = ErrorCode} = Error,


### PR DESCRIPTION
According to the Kafka Protocol documentation, this is a retriable error:
https://kafka.apache.org/protocol#protocol_error_codes
Error: UNKNOWN_TOPIC_OR_PARTITION
Code: 3
Retriable: True
Description: This server does not host this topic-partition.

This is unlike invalid_topic_exception which is not retriable.

We have concretely experienced this causing our topic consumer to hang because the subscriber quietly went away. The subscriber can be made to reliably go away by rebalancing partitions, such that the broker which was the leader is no longer hosting a replica of the partition in question.