### PR TITLE
Add group member callback to provide user_data in group join requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KAFKA_VERSION ?= 1.1
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.7.3
+PROJECT_VERSION = 3.7.4
 
 DEPS = supervisor3 kafka_protocol
 

--- a/changelog.md
+++ b/changelog.md
@@ -136,3 +136,6 @@
 * 3.7.3
   * Bump kafka_protocol version to 2.2.3
   * Discard stale async-ack messages to group subscriber
+* 3.7.4
+  * Add callback to make user_data in group join request
+

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.7.3"},
+  {vsn,"3.7.4"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -1015,7 +1015,8 @@ make_offset_commit_metadata() ->
 %% if assign_partitions callback is not implemented, otherwise
 %% should be set in the assign_partitions callback implemenation.
 user_data(Module, Pid) ->
-  case lists:member({user_data, 1}, Module:module_info(exports)) of
+  %% Module is ensured to be loaded already
+  case erlang:function_exported(Module, user_data, 1) of
     true -> Module:user_data(Pid);
     false -> <<>>
   end.

--- a/src/brod_group_member.erl
+++ b/src/brod_group_member.erl
@@ -46,6 +46,10 @@
 
 -include("brod_int.hrl").
 
+-optional_callbacks([assign_partitions/3,
+                     user_data/1
+                    ]).
+
 %% Call the callback module to initialize assignments.
 %% NOTE: This function is called only when `offset_commit_policy' is
 %%       `consumer_managed' in group config.
@@ -75,6 +79,11 @@
 %% Called before group re-balancing, the member should call
 %% brod:unsubscribe/3 to unsubscribe from all currently subscribed partitions.
 -callback assignments_revoked(pid()) -> ok.
+
+%% Called when making join request. This metadata is to let group leader know
+%% more details about the member. e.g. its location and or capacity etc.
+%% so that leader can make smarter decisions when assigning partitions to it.
+-callback user_data(pid()) -> binary().
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -52,6 +52,7 @@
         , assignments_received/4
         , assignments_revoked/1
         , assign_partitions/3
+        , user_data/1
         ]).
 
 -export([ code_change/3
@@ -266,6 +267,8 @@ commit(Pid) ->
 -spec commit(pid(), brod:topic(), brod:partition(), brod:offset()) -> ok.
 commit(Pid, Topic, Partition, Offset) ->
   gen_server:cast(Pid, {commit_offset, Topic, Partition, Offset}).
+
+user_data(_Pid) -> <<>>.
 
 %%%_* APIs for group coordinator ===============================================
 


### PR DESCRIPTION
This is to allow group members to share states with group leader.
Two use case examples:
1. A member may choose to ignore the assignments_revoked callback, and include its currently assigned partitions in user_data, so the leader can apply a 'sticky' assignment hence it may continue working on the current assignments without interruption
2. A member may include its system capacity (nr. of cores, free memory etc), so the leader can assign partitions in a more balanced fashion.
This however all requires users to implement their own assignment strategy.