### PR TITLE
Fix typo in brod_group_subscriber

### DIFF
--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -185,7 +185,7 @@
 %%   implemented for message processing.
 %% CbInitArg:
 %%   The term() that is going to be passed to CbModule:init/1 when
-%%   initializing the subscriger.
+%%   initializing the subscriber.
 %% @end
 -spec start_link(brod:client(), brod:group_id(), [brod:topic()],
                  brod:group_config(), brod:consumer_config(),
@@ -217,7 +217,7 @@ start_link(Client, GroupId, Topics, GroupConfig,
 %%   implemented for message processing.
 %% CbInitArg:
 %%   The term() that is going to be passed to CbModule:init/1 when
-%%   initializing the subscriger.
+%%   initializing the subscriber.
 %% @end
 -spec start_link(brod:client(), brod:group_id(), [brod:topic()],
                  brod:group_config(), brod:consumer_config(),


### PR DESCRIPTION
I was taking a deep dive into this piece of code and accidentally found a typo on `initializing the subscriger`.

```
%% CbInitArg:
%%   The term() that is going to be passed to CbModule:init/1 when
%%   initializing the subscriber.
```