### PR TITLE
Fix empty assignment handling.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -138,4 +138,9 @@
   * Discard stale async-ack messages to group subscriber
 * 3.7.4
   * Add callback to make user_data in group join request
+* 3.?
+  * Fix empty assignment handling. In case a group member has no partition assigned,
+    `member_assignment` data field in group sync response can either be `null` (kafka 0.10)
+    or a struct having empty `topic_partitions` (kafka 0.11 or later). The later case
+    was not handled properly in `brod` before this fix.
 

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -836,7 +836,8 @@ roundrobin_assign_loop([{Topic, Partition} | Rest] = TopicPartitions,
 %% then fetch the committed offsets of each partition.
 -spec get_topic_assignments(state(), binary() | [kpro:struct()]) ->
         brod:received_assignments().
-get_topic_assignments(#state{}, ?kpro_cg_no_assignment) -> []; %% no assignments
+get_topic_assignments(#state{}, ?kpro_cg_no_assignment) -> [];
+get_topic_assignments(#state{} = State, #{topic_partitions := []}) -> [];
 get_topic_assignments(#state{} = State, Assignment) ->
   PartitionAssignments = kpro:find(topic_partitions, Assignment),
   TopicPartitions0 =


### PR DESCRIPTION
In case a group member has no partition assigned,
`member_assignment` data field in group sync response can either be `null` (kafka 0.10)
or a struct having empty `topic_partitions` (kafka 0.11 or later). The later case
was not handled properly in `brod` before this fix.