### PR TITLE
Fix msg_input type spec

### DIFF
--- a/src/brod.erl
+++ b/src/brod.erl
@@ -168,8 +168,8 @@
 -type value() :: undefined %% no value, transformed to <<>>
                | iodata() %% single value
                | {msg_ts(), binary()} %% one message with timestamp
-               | ?KV(key(), value()) %% backward compatible
-               | ?TKV(msg_ts(), key(), value()) %% backward compatible
+               | [?KV(key(), value())] %% backward compatible
+               | [?TKV(msg_ts(), key(), value())] %% backward compatible
                | kpro:msg_input() %% one magic v2 message
                | kpro:batch_input(). %% maybe nested batch
 


### PR DESCRIPTION
Sorry, the last PR failed to fix the spec.
3.7.6 is not tagged yet, so no version bump is required in this PR.