### PR TITLE
Drop batches in aborted transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KAFKA_VERSION ?= 1.1
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.7.7
+PROJECT_VERSION = 3.7.8
 
 DEPS = supervisor3 kafka_protocol
 

--- a/changelog.md
+++ b/changelog.md
@@ -149,3 +149,7 @@
 * 3.7.7
   * Fix `badrecord` race: message-set is delivered to `brod_group_subscriber` after
     unsubscribed from `brod_consumer`.
+* 3.7.8
+  * Drop batches in aborted transactions (and all control batches)
+    also improve offset fast-forwarding when empty batches are received
+

--- a/elvis.config
+++ b/elvis.config
@@ -61,6 +61,14 @@
                        }}
                    , {elvis_style, no_debug_call}
                    ]
+         },
+        #{ dirs => ["test"]
+         , filter => "*.erl"
+         , rules => [ {elvis_style, line_length,
+                       #{ limit => 80
+                        , skip_comments => false
+                        }}
+                    ]
          }
       ]
      }

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.7.7"},
+  {vsn,"3.7.8"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},

--- a/test/brod_consumer_SUITE.erl
+++ b/test/brod_consumer_SUITE.erl
@@ -162,7 +162,8 @@ test_drop_aborted(Config, QueryApiVsn) ->
         Opts = #{txn_ctx => TxnCtx, first_sequence => 0},
         Batch = [#{key => Key, value => <<>>}],
         ProduceReq = kpro_req_lib:produce(Vsn, Topic, Partition, Batch, Opts),
-        {ok, LeaderConn} = brod_client:get_leader_connection(Client, Topic, Partition),
+        {ok, LeaderConn} =
+          brod_client:get_leader_connection(Client, Topic, Partition),
         {ok, ProduceRsp} = kpro:request_sync(LeaderConn, ProduceReq, 5000),
         {ok, Offset} = brod_utils:parse_rsp(ProduceRsp),
         case CommitOrAbort of
@@ -266,7 +267,7 @@ test_fetch_aborted_from_the_middle(Config) when is_list(Config) ->
   ok = kpro:close_connection(Conn),
   {OffsetEnd, KeyEnd} = Send(), %% the end mark
   ?assertEqual([{OffsetBgn, KeyBgn}], Fetch(OffsetBgn, #{max_bytes => 12})),
-  ?assertEqual([{OffsetEnd, KeyEnd}], Fetch(OffsetEnd, #{max_bytes => 1000000})),
+  ?assertEqual([{OffsetEnd, KeyEnd}], Fetch(OffsetEnd, #{max_bytes => 100000})),
   ?assertEqual([{OffsetEnd, KeyEnd}], Fetch(Offset1, #{max_bytes => 12})),
   ?assertEqual([{OffsetEnd, KeyEnd}], Fetch(Offset1 + 1, #{max_bytes => 12})),
   ?assertEqual([{OffsetEnd, KeyEnd}], Fetch(Offset2, #{max_bytes => 12})),

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -124,12 +124,13 @@ init(_GroupId,
              , is_assign_partitions = IsAssignPartitions
              }}.
 
-handle_message(Topic, Partition, Message, #state{ ct_case_ref     = Ref
-                                                , ct_case_pid     = Pid
-                                                , is_async_ack    = IsAsyncAck
-                                                , is_async_commit = IsAsyncCommit
-                                                , is_assign_partitions = IsAssignPartitions
-                                                } = State) ->
+handle_message(Topic, Partition, Message,
+               #state{ ct_case_ref     = Ref
+                     , ct_case_pid     = Pid
+                     , is_async_ack    = IsAsyncAck
+                     , is_async_commit = IsAsyncCommit
+                     , is_assign_partitions = IsAssignPartitions
+                     } = State) ->
   #kafka_message{ offset = Offset
                 , value  = Value
                 } = Message,
@@ -145,11 +146,15 @@ get_committed_offsets(_GroupId, _TopicPartitions, State) ->
   %% always return []: always fetch from latest available offset
   {ok, [], State}.
 
-assign_partitions(MemberPid, TopicPartitions, #state{is_assign_partitions = false} = _CbState) ->
-  PartitionsAssignments = [{Topic, [PartitionsN]} || {Topic, PartitionsN} <- TopicPartitions],
+assign_partitions(MemberPid, TopicPartitions,
+                  #state{is_assign_partitions = false} = _CbState) ->
+  PartitionsAssignments = [{Topic, [PartitionsN]}
+                           || {Topic, PartitionsN} <- TopicPartitions],
   [{element(1, hd(MemberPid)), PartitionsAssignments}];
-assign_partitions(MemberPid, TopicPartitions, #state{is_assign_partitions = true} = CbState) ->
-  PartitionsAssignments = [{Topic, [PartitionsN]} || {Topic, PartitionsN} <- TopicPartitions],
+assign_partitions(MemberPid, TopicPartitions,
+                  #state{is_assign_partitions = true} = CbState) ->
+  PartitionsAssignments = [{Topic, [PartitionsN]}
+                           || {Topic, PartitionsN} <- TopicPartitions],
   {CbState, [{element(1, hd(MemberPid)), PartitionsAssignments}]}.
 
 %%%_* Test functions ===========================================================
@@ -247,7 +252,8 @@ t_async_acks(Config) when is_list(Config) ->
                    ],
   CaseRef = t_async_acks,
   CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true, _IsAsyncCommit = false, _IsAssignPartitions = false},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true,
+              _IsAsyncCommit = false, _IsAssignPartitions = false},
   Partition = 0,
   {ok, SubscriberPid} =
     brod:start_link_group_subscriber(?CLIENT_ID, ?GROUP_ID, [?TOPIC1],
@@ -301,7 +307,8 @@ t_consumer_crash(Config) when is_list(Config) ->
                    ],
   CaseRef = t_consumer_crash,
   CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true, _IsAsyncCommit = false, _IsAssignPartitions = false},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true,
+              _IsAsyncCommit = false, _IsAssignPartitions = false},
   Partition = 0,
   {ok, SubscriberPid} =
     brod:start_link_group_subscriber(?CLIENT_ID, ?GROUP_ID, [?TOPIC1],
@@ -362,7 +369,7 @@ t_consumer_crash(Config) when is_list(Config) ->
 t_2_members_subscribe_to_different_topics({init, Config}) ->
   meck_subscribe_unsubscribe(),
   Config;
-t_2_members_subscribe_to_different_topics({'end', Config}) when is_list(Config) ->
+t_2_members_subscribe_to_different_topics({'end', Conf}) when is_list(Conf) ->
   meck:unload(brod);
 t_2_members_subscribe_to_different_topics(Config) when is_list(Config) ->
   MaxSeqNo = 100,
@@ -376,7 +383,8 @@ t_2_members_subscribe_to_different_topics(Config) when is_list(Config) ->
                    ],
   CaseRef = t_2_members_subscribe_to_different_topics,
   CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = false, _IsAsyncCommit = false, _IsAssignPartitions = false},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = false,
+              _IsAsyncCommit = false, _IsAssignPartitions = false},
   {ok, SubscriberPid1} =
     brod:start_link_group_subscriber(?CLIENT_ID, ?GROUP_ID, [?TOPIC2],
                                      GroupConfig, ConsumerConfig,
@@ -447,7 +455,8 @@ t_2_members_one_partition(Config) when is_list(Config) ->
                    ],
   CaseRef = t_2_members_one_partition,
   CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = false, _IsAsyncCommit = false, _IsAssignPartitions = false},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = false,
+              _IsAsyncCommit = false, _IsAssignPartitions = false},
   {ok, SubscriberPid1} =
     brod:start_link_group_subscriber(?CLIENT_ID, ?GROUP_ID, [Topic],
                                      GroupConfig, ConsumerConfig,
@@ -489,7 +498,8 @@ t_2_members_one_partition(Config) when is_list(Config) ->
 
 t_async_commit({init, Config}) ->
   meck_subscribe_unsubscribe(),
-  meck:new(brod_group_coordinator, [passthrough, no_passthrough_cover, no_history]),
+  meck:new(brod_group_coordinator,
+           [passthrough, no_passthrough_cover, no_history]),
   Config;
 t_async_commit({'end', _Config}) ->
   meck:unload(brod);
@@ -497,9 +507,11 @@ t_async_commit(Config) when is_list(Config) ->
   CaseRef = t_async_commit,
   CasePid = self(),
   Partition = 0,
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = false, _IsAsyncCommit = true, _IsAssignPartitions = false},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = false,
+              _IsAsyncCommit = true, _IsAssignPartitions = false},
   %% use a one-time gid for clean test
-  GroupId = list_to_binary("one-time-gid-" ++ integer_to_list(rand:uniform(1000000000))),
+  GroupId = list_to_binary("one-time-gid-" ++
+                           integer_to_list(rand:uniform(1000000000))),
   StartSubscriber =
     fun() ->
         GroupConfig = [],
@@ -529,11 +541,12 @@ t_async_commit(Config) when is_list(Config) ->
         timer:sleep(5500)
     end,
   Pid1 = StartSubscriber(),
-  {ok, Offset} = brod:produce_sync_offset(?CLIENT_ID, ?TOPIC4, Partition, <<>>, <<"test">>),
+  {ok, Offset} = brod:produce_sync_offset(?CLIENT_ID, ?TOPIC4,
+                                          Partition, <<>>, <<"test">>),
   ct:pal("Produced at offset = ~p", [Offset]),
   ?assertEqual([[Offset]],
-               receive_match(4000, ?MSG(CaseRef, '_', ?TOPIC4, Partition, '$1', '_'))
-              ),
+               receive_match(4000, ?MSG(CaseRef, '_', ?TOPIC4,
+                                        Partition, '$1', '_'))),
   %% Slightly unsound: commit _previous_ offset to avoid starting
   %% brod_consumer with `latest' offset and thus losing all data
   %% during restart:
@@ -542,7 +555,8 @@ t_async_commit(Config) when is_list(Config) ->
   Pid2 = EmulateRestart(Pid1),
   %% Since we haven't commited offset, our message should be replayed:
   ?assertEqual([[Offset]],
-               receive_match(4000, ?MSG(CaseRef, '_', ?TOPIC4, Partition, '$1', '_'))
+               receive_match(4000, ?MSG(CaseRef, '_', ?TOPIC4,
+                                        Partition, '$1', '_'))
               ),
   %% Commit offset and restart subscriber again:
   CommitOffset(Pid2, Offset),
@@ -554,10 +568,10 @@ t_async_commit(Config) when is_list(Config) ->
   brod_group_subscriber:stop(Pid3),
   ok.
 
-t_assign_partitions_handles_updating_state({init, Config}) when is_list(Config) ->
+t_assign_partitions_handles_updating_state({init, Cfg}) when is_list(Cfg) ->
   meck_subscribe_unsubscribe(),
-  Config;
-t_assign_partitions_handles_updating_state({'end', Config}) when is_list(Config) ->
+  Cfg;
+t_assign_partitions_handles_updating_state({'end', Cfg}) when is_list(Cfg) ->
   meck:unload(brod);
 t_assign_partitions_handles_updating_state(Config) when is_list(Config) ->
   %% use consumer managed offset commit behaviour
@@ -572,7 +586,8 @@ t_assign_partitions_handles_updating_state(Config) when is_list(Config) ->
                    ],
   CaseRef = t_assign_partitions_handles_updating_state,
   CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true, _IsAsyncCommit = false, _IsAssignPartitions = true},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true,
+              _IsAsyncCommit = false, _IsAssignPartitions = true},
   {ok, SubscriberPid} =
     brod:start_link_group_subscriber(?CLIENT_ID, ?GROUP_ID, [?TOPIC1],
                                      GroupConfig, ConsumerConfig,

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -146,9 +146,11 @@ t_produce_sync_offset(Config) when is_list(Config) ->
   Client = ?config(client),
   Partition = 0,
   {T1, K1, V1} = make_unique_tkv(),
-  {ok, O1} = brod:produce_sync_offset(Client, ?TOPIC, Partition, <<>>, [{T1, K1, V1}]),
+  {ok, O1} = brod:produce_sync_offset(Client, ?TOPIC, Partition,
+                                      <<>>, [{T1, K1, V1}]),
   {T2, K2, V2} = make_unique_tkv(),
-  {ok, O2} = brod:produce_sync_offset(Client, ?TOPIC, Partition, <<>>, [{T2, K2, V2}]),
+  {ok, O2} = brod:produce_sync_offset(Client, ?TOPIC, Partition,
+                                      <<>>, [{T2, K2, V2}]),
   ReceiveFun =
     fun(ExpectedK, ExpectedV) ->
       receive

--- a/test/brod_topic_subscriber_SUITE.erl
+++ b/test/brod_topic_subscriber_SUITE.erl
@@ -209,7 +209,8 @@ t_begin_offset(Config) when is_list(Config) ->
   SendFun =
     fun(I) ->
       Value = integer_to_binary(I),
-      {ok, Offset} = brod:produce_sync_offset(?CLIENT_ID, ?TOPIC, Partition, <<>>, Value),
+      {ok, Offset} = brod:produce_sync_offset(?CLIENT_ID, ?TOPIC,
+                                              Partition, <<>>, Value),
       Offset
     end,
   RecvFun =
@@ -229,7 +230,8 @@ t_begin_offset(Config) when is_list(Config) ->
   Offset1 = SendFun(222),
   Offset2 = SendFun(333),
   %% Start as if committed Offset1, expect it to start fetching from Offset2
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true, _ConsumerOffsets = [{0, Offset1}]},
+  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true,
+              _ConsumerOffsets = [{0, Offset1}]},
   {ok, SubscriberPid} =
     brod:start_link_topic_subscriber(?CLIENT_ID, ?TOPIC, ConsumerConfig,
                                      ?MODULE, InitArgs),


### PR DESCRIPTION
Drop all control batches.
And improve offset fast-forwarding when empty sets are received.