### PR TITLE
Fix wrong handeling of empty fetch response.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,18 @@ DEPS = supervisor3 kafka_protocol
 ERLC_OPTS = -Werror +warn_unused_vars +warn_shadow_vars +warn_unused_import +warn_obsolete_guard +debug_info -Dbuild_brod_cli
 
 dep_supervisor3_commit = 1.1.8
-dep_kafka_protocol_commit = 2.2.7
+dep_kafka_protocol_commit = 2.2.8
 dep_kafka_protocol = git https://github.com/klarna/kafka_protocol.git $(dep_kafka_protocol_commit)
 
 EDOC_OPTS = preprocess, {macros, [{build_brod_cli, true}]}
 
 ## Make app the default target
 ## To avoid building a release when brod is used as a erlang.mk project's dependency
-app::
+app:: vsn-check
 
 include erlang.mk
 
-compile:
+compile: vsn-check
 	@rebar3 compile
 
 test-env:

--- a/changelog.md
+++ b/changelog.md
@@ -139,7 +139,7 @@
 * 3.7.4
   * Add callback to make user_data in group join request
 * 3.7.5
-  * Bump kafka protocol version to 2.2.7
+  * Bump kafka_protocol version to 2.2.7
   * Fix empty assignment handling. In case a group member has no partition assigned,
     `member_assignment` data field in group sync response can either be `null` (kafka 0.10)
     or a struct having empty `topic_partitions` (kafka 0.11 or later). The later case
@@ -155,4 +155,6 @@
 * 3.7.9
   * Fix brod-cli escript include apps
   * Fix brod-cli sub-record formatting crash
+  * Upgrade to kafka_protocol 2.2.8 to discard replica_not_available error code in metadata response
+  * Fix empty responses field in fetch response #323
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [ {supervisor3, "1.1.8"}
-       , {kafka_protocol, "2.2.7"}
+       , {kafka_protocol, "2.2.8"}
        ]}.
 {edoc_opts, [{preprocess, true}, {macros, [{build_brod_cli, true}]}]}.
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.


### PR DESCRIPTION
Empty fetch response happens only in incremental fetch sessions.
(which we do not support yet)

The current parsing code is a copy-paste from kafka_protocol test_lib code
which is fine.
But the comment is wrong: It's fetch session not transactional session
which is a entirely different thing.
And the handling is even more wrong: In case empty fetch response is
received, it should not advance begin_offset, but keep retrying the one
used in the last fetch request, because essentially an empty
response implies no new offsets and no partition metadata change either.

Noticed this when investigating #321, but it should not be the cause of it,
because the bug is reported on brod 3.4,
the highest fetch request supported in 3.4 is version 3 (session is introduced in version 7).
we do not support incremental fetches in latest brod either.

Unless there is a bug in kafka which may take a random fetch request as
a part of some session.