### PR TITLE
brod_consumer should compare begin_offset to last stable offset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KAFKA_VERSION ?= 1.1
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.7.9
+PROJECT_VERSION = 3.7.10
 
 DEPS = supervisor3 kafka_protocol
 

--- a/changelog.md
+++ b/changelog.md
@@ -157,4 +157,10 @@
   * Fix brod-cli sub-record formatting crash
   * Upgrade to kafka_protocol 2.2.8 to discard replica_not_available error code in metadata response
   * Fix empty responses field in fetch response #323
+* 3.7.10
+  * Compare begin_offset with last stable offset before advancing to next offset in case empty
+    batch is received. Prior to this version, fetch attempts on unstable messages (messages
+    belong to open transactions (transactions which are neigher committed nor aborted),
+    may result in an empty message set, then `brod_consumer` or `brod_utils:fetch` jumps to
+    the next offset (if it is less than high-watermark offset).
 

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.7.9"},
+  {vsn,"3.7.10"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},


### PR DESCRIPTION
If start fetching from an uncommitted offset, kafka may reply empty batch.
Prior to this change brod_consumer takes this scenario as a
broken offset sequence due to compaction.
Now it compares the sent begin_offset to last_stable_offset to ensure
that it's not due to uncommitted transaction.