### PR TITLE
Allow brod_consumer to spawn kafka connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KAFKA_VERSION ?= 1.1
 PROJECT = brod
 PROJECT_DESCRIPTION = Kafka client library in Erlang
-PROJECT_VERSION = 3.7.11
+PROJECT_VERSION = 3.8.0
 
 DEPS = supervisor3 kafka_protocol
 

--- a/changelog.md
+++ b/changelog.md
@@ -173,3 +173,6 @@
   * Add callbacks to allow `brod_client:stop_producer` and `brod_client:stop_consumer` to remove
     the stopped child references from the supervisor and clean up the client ets table to allow
     later restart.
+  * Support scram SASL authentication in brod-cli
+  * Made possible to start-link or supervise `brod_consumer` in user apps, instead of always
+    under `brod_client`'s `brod_consumers_sup`

--- a/src/brod.app.src
+++ b/src/brod.app.src
@@ -1,7 +1,7 @@
 %% -*- mode:erlang -*-
 {application,brod,
  [{description,"Apache Kafka Erlang client library"},
-  {vsn,"3.7.11"},
+  {vsn,"3.8.0"},
   {registered,[]},
   {applications,[kernel,stdlib,kafka_protocol,supervisor3]},
   {env,[]},


### PR DESCRIPTION
Prior to this commit, partition leader connections
are managed by brod_client and shared between
partition workers (brod_producer:s and brod_consumer:s)

Now bootstrap hosts (plus connection config) is supported
as first arg to brod_consumer:start_link.
This should allow users to link or supervise brod_consumer
instead of always under brod_client's brod_consumers_sup.