### PR TITLE
Fix handle_message callback spec of group subscriber

### DIFF
--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -91,7 +91,7 @@
 %%
 -callback handle_message(brod:topic(),
                          brod:partition(),
-                         brod:message(),
+                         brod:message() | brod:message_set(),
                          cb_state()) -> {ok, cb_state()} |
                                         {ok, ack, cb_state()} |
                                         {ok, ack_no_commit, cb_state()}.


### PR DESCRIPTION
Seems like `brod_group_subscriber` callback `handle_message` may be called with message_set, not just message.

https://github.com/klarna/brod/blob/f45adf912764cd75757783f6881c7a5371d0a001/src/brod_group_subscriber.erl#L505-L522

