### PR TITLE
Create and Delete Topic Apis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
       # run dialyzer only in otp 22
       rebar3 dialyzer
       # test against kafka 0.9 in otp 22
-      export KAFKA_VERSION="0.9"
+      export KAFKA_VERSION="1.0"
     fi
     if [ $OTP_VSN -eq 21 ]; then
       # test against kafka 2.2 in otp 21

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
       # run dialyzer only in otp 22
       rebar3 dialyzer
       # test against kafka 0.9 in otp 22
-      export KAFKA_VERSION="1.0"
+      export KAFKA_VERSION="0.9"
     fi
     if [ $OTP_VSN -eq 21 ]; then
       # test against kafka 2.2 in otp 21

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ hex-publish: distclean
 	@rebar3 hex docs
 
 ## tests that require kafka running at localhost
-INTEGRATION_CTS = brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber
+INTEGRATION_CTS = brod brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber
 
 ## integration tests
 it: ut $(INTEGRATION_CTS:%=it-%)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ hex-publish: distclean
 	@rebar3 hex docs
 
 ## tests that require kafka running at localhost
-INTEGRATION_CTS = brod brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber
+INTEGRATION_CTS = brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber brod
 
 ## integration tests
 it: ut $(INTEGRATION_CTS:%=it-%)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ hex-publish: distclean
 	@rebar3 hex docs
 
 ## tests that require kafka running at localhost
-INTEGRATION_CTS = brod brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber
+INTEGRATION_CTS = brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber
 
 ## integration tests
 it: ut $(INTEGRATION_CTS:%=it-%)

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ hex-publish: distclean
 	@rebar3 hex docs
 
 ## tests that require kafka running at localhost
-INTEGRATION_CTS = brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber brod
+INTEGRATION_CTS = brod brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber
 
 ## integration tests
 it: ut $(INTEGRATION_CTS:%=it-%)

--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ brod:delete_topics(Hosts, [Topic], Timeout).
 brod:resolve_offset(Hosts, Topic, Partition).
 ```
 
+Caution the above delete_topics can fail if you do not have `delete.topic.enable` set to true in your kafka config
+
 # brod-cli: A command line tool to interact with Kafka
 
 This will build a self-contained binary with brod application

--- a/README.md
+++ b/README.md
@@ -520,4 +520,3 @@ brod commits -b localhost:9092 -i the-group-id -t topic-name -o "0:10000" --prot
 * Support scram-sasl in brod-cli
 * lz4 compression & decompression
 * Transactional produce APIs
-

--- a/README.md
+++ b/README.md
@@ -405,8 +405,20 @@ await response and then close the connection.
 Hosts = [{"localhost", 9092}].
 Topic = <<"topic">>.
 Partition = 0.
+Timeout = 1000.
+TopicConfigs = [
+  #{
+    config_entries => [],
+    num_partitions => 1,
+    replica_assignment => [],
+    replication_factor => 1,
+    topic => Topic
+  }
+]
 brod:get_metadata(Hosts).
+brod:create_topics(Hosts, TopicConfigs, #{timeout => Timeout}).
 brod:get_metadata(Hosts, [Topic]).
+brod:delete_topics(Hosts, [Topic], Timeout).
 brod:resolve_offset(Hosts, Topic, Partition).
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Why "brod"? [http://en.wikipedia.org/wiki/Max_Brod](http://en.wikipedia.org/wiki
 # Working With Kafka 0.9.x or Earlier
 
 Make sure `{query_api_versions, false}` exists in client config.
-This is because `ApiVersionRequest` was introduced in kafka 0.10, 
+This is because `ApiVersionRequest` was introduced in kafka 0.10,
 sending such request to older version brokers will cause connection failure.
 
 e.g. in sys.config:
@@ -95,14 +95,14 @@ Brod supervision (and process link) tree.
 
 # Clients
 
-A `brod_client` in brod is a `gen_server` responsible for establishing and 
-maintaining tcp sockets connecting to kafka brokers. 
-It also manages per-topic-partition producer and consumer processes under 
+A `brod_client` in brod is a `gen_server` responsible for establishing and
+maintaining tcp sockets connecting to kafka brokers.
+It also manages per-topic-partition producer and consumer processes under
 two-level supervision trees.
 
 ## Start clients by default
 
-You may include client configs in sys.config have them started by default 
+You may include client configs in sys.config have them started by default
 (by application controller)
 
 Example of configuration (for sys.config):
@@ -125,7 +125,7 @@ Example of configuration (for sys.config):
 
 ## Start brod client on demand
 
-You may also call `brod:start_client/1,2,3` to start a client on demand, 
+You may also call `brod:start_client/1,2,3` to start a client on demand,
 which will be added to brod supervision tree.
 
 ```erlang
@@ -239,8 +239,8 @@ brod:produce(_Client    = brod_client_1,
 
 ## Handle Acks from Kafka as Messages
 
-For async produce APIs `brod:produce/3` and `brod:produce/5`, 
-the caller should expect a message of below pattern for each produce call. 
+For async produce APIs `brod:produce/3` and `brod:produce/5`,
+the caller should expect a message of below pattern for each produce call.
 
 ```erlang
 #brod_produce_reply{ call_ref = CallRef %% returned from brod:produce
@@ -249,84 +249,84 @@ the caller should expect a message of below pattern for each produce call.
 ```
 Add `-include_lib("brod/include/brod.hrl").` to use the record.
 
-In case the `brod:produce` caller is a process like `gen_server` which 
-receives ALL messages, the callers should keep the call references in its 
-looping state and match the replies against them when received. 
+In case the `brod:produce` caller is a process like `gen_server` which
+receives ALL messages, the callers should keep the call references in its
+looping state and match the replies against them when received.
 Otherwise `brod:sync_produce_request/1` can be used to block-wait for acks.
 
-NOTE: If `required_acks` is set to `none` in producer config, 
-kafka will NOT ack the requests, and the reply message is sent back 
+NOTE: If `required_acks` is set to `none` in producer config,
+kafka will NOT ack the requests, and the reply message is sent back
 to caller immediately after the message has been sent to the socket process.
 
-NOTE: The replies are only strictly ordered per-partition. 
-i.e. if the caller is producing to two or more partitions, 
-it may receive replies ordered differently than in which order 
+NOTE: The replies are only strictly ordered per-partition.
+i.e. if the caller is producing to two or more partitions,
+it may receive replies ordered differently than in which order
 `brod:produce` API was called.
 
 ## Handle Acks from Kafka in Callback Function
 
-Async APIs `brod:produce_cb/4` and `brod:produce_cb/6` allow callers to 
-provided a callback function to handle acknowledgements from kafka. 
-In this case, the caller may want to monitor the producer process because 
+Async APIs `brod:produce_cb/4` and `brod:produce_cb/6` allow callers to
+provided a callback function to handle acknowledgements from kafka.
+In this case, the caller may want to monitor the producer process because
 then they know that the callbacks will not be evaluated if the producer is 'DOWN',
 and there is perhaps a need for retry.
 
 # Consumers
 
-Kafka consumers work in poll mode. In brod, `brod_consumer` is the poller, 
-which is constantly asking for more data from the kafka node which is a leader 
+Kafka consumers work in poll mode. In brod, `brod_consumer` is the poller,
+which is constantly asking for more data from the kafka node which is a leader
 for the given partition.
 
-By subscribing to `brod_consumer` a process should receive the polled message 
+By subscribing to `brod_consumer` a process should receive the polled message
 sets (not individual messages) into its mailbox.
 
-In brod, we have so far implemented two different subscribers 
-(`brod_topic_subscriber` and `brod_group_subscriber`), 
+In brod, we have so far implemented two different subscribers
+(`brod_topic_subscriber` and `brod_group_subscriber`),
 hopefully covered most of the common use cases.
 
-For maximum flexibility, an applications may implement their own 
+For maximum flexibility, an applications may implement their own
 per-partition subscriber.
 
-Below diagrams illustrate 3 examples of how subscriber processes may work 
+Below diagrams illustrate 3 examples of how subscriber processes may work
 with `brod_consumer`.
 
 ## Partition subscriber
 ![](https://cloud.githubusercontent.com/assets/164324/19621677/5e469350-9897-11e6-8c8e-8a6a4f723f73.jpg)
 
-This gives the best flexibility as the per-partition subscribers work 
+This gives the best flexibility as the per-partition subscribers work
 directly with per-partition pollers.
 
-The messages are delivered to subscribers in message sets (batches), 
-not individual messages, (however the subscribers are allowed to 
+The messages are delivered to subscribers in message sets (batches),
+not individual messages, (however the subscribers are allowed to
 ack individual offsets).
 
 ## Topic subscriber (`brod_topic_subscriber`)
 ![](https://cloud.githubusercontent.com/assets/164324/19621951/41e1d75e-989e-11e6-9bc2-49fe814d3020.jpg)
 
-A topic subscriber provides the easiest way to receive and process 
-messages from ALL partitions of a given topic.  See `brod_demo_cg_collector` 
+A topic subscriber provides the easiest way to receive and process
+messages from ALL partitions of a given topic.  See `brod_demo_cg_collector`
 and `brod_demo_topic_subscriber` for example.
 
-Users may choose to implement the `brod_topic_subscriber` behaviour callbacks 
-in a module, or simply provide an anonymous callback function to have the 
+Users may choose to implement the `brod_topic_subscriber` behaviour callbacks
+in a module, or simply provide an anonymous callback function to have the
 individual messages processed.
 
 ## Group subscriber (`brod_group_subscriber`)
 ![](https://cloud.githubusercontent.com/assets/164324/19621956/59d76a9a-989e-11e6-9633-a0bc677e06f3.jpg)
 
-Similar to topic subscriber, the `brod_group_subscriber` behaviour callbacks 
-are to be implemented to process individual messages. See 
-`brod_demo_group_subscriber_koc` and `brod_demo_group_subscriber_loc` 
+Similar to topic subscriber, the `brod_group_subscriber` behaviour callbacks
+are to be implemented to process individual messages. See
+`brod_demo_group_subscriber_koc` and `brod_demo_group_subscriber_loc`
 for example.
 
-A group subscriber is started by giving a set of topics, some 
-(maybe none, or maybe all) of the partitions in the topic set will be 
-assigned to it, then the subscriber should subscribe to ALL the assigned 
+A group subscriber is started by giving a set of topics, some
+(maybe none, or maybe all) of the partitions in the topic set will be
+assigned to it, then the subscriber should subscribe to ALL the assigned
 partitions.
 
-Users may also choose to implement the `brod_group_member` behaviour (callbacks 
-for `brod_group_coordinator`) for a different group subscriber (e.g. spawn 
-one subscriber per partition), see [brucke](https://github.com/klarna/brucke) 
+Users may also choose to implement the `brod_group_member` behaviour (callbacks
+for `brod_group_coordinator`) for a different group subscriber (e.g. spawn
+one subscriber per partition), see [brucke](https://github.com/klarna/brucke)
 for example.
 
 ### Example of group consumer which commits offsets to Kafka
@@ -507,6 +507,5 @@ brod commits -b localhost:9092 -i the-group-id -t topic-name -o "0:10000" --prot
 * HTML tagged EDoc
 * Support scram-sasl in brod-cli
 * lz4 compression & decompression
-* Create/delete topic APIs
 * Transactional produce APIs
 

--- a/changelog.md
+++ b/changelog.md
@@ -178,3 +178,4 @@
     under `brod_client`'s `brod_consumers_sup`
 * 3.8.1
   * Handle the case when high_watermark < last_stable_offset in fetch resp
+  * Added in support for delete and create topics apis

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -45,6 +45,7 @@ function create_topic {
 }
 
 create_topic "dummy" || true
+create_topic "brod_SUITE"
 create_topic "brod-client-SUITE-topic"
 create_topic "brod_consumer_SUITE"
 create_topic "brod_producer_SUITE"            2

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -78,6 +78,11 @@
         , start_link_topic_subscriber/7
         ]).
 
+%% Topic APIs
+-export([ delete_topics/3
+        , delete_topics/4
+        ]).
+
 %% APIs for quick metadata or message inspection and brod_cli
 -export([ get_metadata/1
         , get_metadata/2
@@ -739,6 +744,22 @@ start_link_topic_subscriber(Client, Topic, Partitions,
   brod_topic_subscriber:start_link(Client, Topic, Partitions,
                                    ConsumerConfig, MessageType,
                                    CbModule, CbInitArg).
+
+%% @doc delete topic(s) from kafka
+%% Return the message body of `delete_topics, response.
+%% See `kpro_schema.erl' for struct details
+-spec delete_topics([endpoint()], [topic()], pos_integer()) ->
+        {ok, kpro:struct()} | {error, any()}.
+delete_topics(Hosts, Topics, Timeout) ->
+  brod_utils:delete_topics(Hosts, Topics, Timeout).
+
+%% @doc delete topic(s) from kafka
+%% Return the message body of `delete_topics, response.
+%% See `kpro_schema.erl' for struct details
+-spec delete_topics([endpoint()], [topic()], pos_integer(), conn_config()) ->
+        {ok, kpro:struct()} | {error, any()}.
+delete_topics(Hosts, Topics, Timeout, Options) ->
+  brod_utils:delete_topics(Hosts, Topics, Timeout, Options).
 
 %% @doc Fetch broker metadata
 %% Return the message body of `metadata' response.

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -79,7 +79,9 @@
         ]).
 
 %% Topic APIs
--export([ delete_topics/3
+-export([ create_topics/3
+        , create_topics/4
+        , delete_topics/3
         , delete_topics/4
         ]).
 
@@ -173,6 +175,7 @@
 -type portnum() :: pos_integer().
 -type endpoint() :: {hostname(), portnum()}.
 -type topic() :: kpro:topic().
+-type topic_config() :: kpro:struct().
 -type partition() :: kpro:partition().
 -type topic_partition() :: {topic(), partition()}.
 -type offset() :: kpro:offset().
@@ -744,6 +747,24 @@ start_link_topic_subscriber(Client, Topic, Partitions,
   brod_topic_subscriber:start_link(Client, Topic, Partitions,
                                    ConsumerConfig, MessageType,
                                    CbModule, CbInitArg).
+
+%% @doc create topic(s) in kafka
+%% Return the message body of `create_topics, response.
+%% See `kpro_schema.erl' for struct details
+-spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
+                    validate_only => boolean()}) ->
+        {ok, kpro:struct()} | {error, any()}.
+create_topics(Hosts, TopicConfigs, RequestConfigs) ->
+  brod_utils:create_topics(Hosts, TopicConfigs, RequestConfigs).
+
+%% @doc create topic(s) in kafka
+%% Return the message body of `create_topics, response.
+%% See `kpro_schema.erl' for struct details
+-spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
+                    validate_only => boolean()}, conn_config()) ->
+        {ok, kpro:struct()} | {error, any()}.
+create_topics(Hosts, TopicConfigs, RequestConfigs, Options) ->
+  brod_utils:create_topics(Hosts, TopicConfigs, RequestConfigs, Options).
 
 %% @doc delete topic(s) from kafka
 %% Return the message body of `delete_topics, response.

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -755,8 +755,8 @@ start_link_topic_subscriber(Client, Topic, Partitions,
 create_topics(Hosts, TopicConfigs, RequestConfigs) ->
   brod_utils:create_topics(Hosts, TopicConfigs, RequestConfigs).
 
-%% @doc create topic(s) in kafka
-%% Return the message body of `create_topics, response.
+%% @doc Create topic(s) in kafka
+%% Return the message body of `create_topics', response.
 %% See `kpro_schema.erl' for struct details
 -spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
                     validate_only => boolean()}, conn_config()) ->
@@ -770,8 +770,8 @@ create_topics(Hosts, TopicConfigs, RequestConfigs, Options) ->
 delete_topics(Hosts, Topics, Timeout) ->
   brod_utils:delete_topics(Hosts, Topics, Timeout).
 
-%% @doc delete topic(s) from kafka
-%% Return the message body of `delete_topics, response.
+%% @doc Delete topic(s) from kafka
+%% Return the message body of `delete_topics', response.
 %% See `kpro_schema.erl' for struct details
 -spec delete_topics([endpoint()], [topic()], pos_integer(), conn_config()) ->
         {ok, kpro:struct()} | {error, any()}.

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -748,9 +748,7 @@ start_link_topic_subscriber(Client, Topic, Partitions,
                                    ConsumerConfig, MessageType,
                                    CbModule, CbInitArg).
 
-%% @doc create topic(s) in kafka
-%% Return the message body of `create_topics, response.
-%% See `kpro_schema.erl' for struct details
+%% @equiv create_topics(Hosts, TopicsConfigs, RequestConfigs, [])
 -spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
                     validate_only => boolean()}) ->
         {ok, kpro:struct()} | {error, any()}.
@@ -766,9 +764,7 @@ create_topics(Hosts, TopicConfigs, RequestConfigs) ->
 create_topics(Hosts, TopicConfigs, RequestConfigs, Options) ->
   brod_utils:create_topics(Hosts, TopicConfigs, RequestConfigs, Options).
 
-%% @doc delete topic(s) from kafka
-%% Return the message body of `delete_topics, response.
-%% See `kpro_schema.erl' for struct details
+%% @equiv delete_topics(Hosts, Topics, Timeout, [])
 -spec delete_topics([endpoint()], [topic()], pos_integer()) ->
         {ok, kpro:struct()} | {error, any()}.
 delete_topics(Hosts, Topics, Timeout) ->

--- a/src/brod_kafka_apis.erl
+++ b/src/brod_kafka_apis.erl
@@ -149,6 +149,7 @@ supported_versions(API) ->
     sync_group       -> {0, 0};
     describe_groups  -> {0, 0};
     list_groups      -> {0, 0};
+    delete_topics    -> {0, 0};
     _                -> erlang:error({unsupported_api, API})
   end.
 

--- a/src/brod_kafka_apis.erl
+++ b/src/brod_kafka_apis.erl
@@ -149,6 +149,7 @@ supported_versions(API) ->
     sync_group       -> {0, 0};
     describe_groups  -> {0, 0};
     list_groups      -> {0, 0};
+    create_topics    -> {0, 0};
     delete_topics    -> {0, 0};
     _                -> erlang:error({unsupported_api, API})
   end.

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -17,7 +17,8 @@
 %% @doc Help functions to build request messages.
 -module(brod_kafka_request).
 
--export([ fetch/7
+-export([ delete_topics/3
+        , fetch/7
         , list_groups/1
         , list_offsets/4
         , join_group/2
@@ -52,6 +53,14 @@ produce(MaybePid, Topic, Partition, BatchInput,
                         , ack_timeout => AckTimeout
                         , compression => Compression
                         }).
+
+%% @doc Make a delete_topics request.
+-spec delete_topics(vsn() | conn(), [topic()], pos_integer()) -> kpro:req().
+delete_topics(Connection, Topics, Timeout) when is_pid(Connection) ->
+  Vsn = brod_kafka_apis:pick_version(Connection, delete_topics),
+  delete_topics(Vsn, Topics, Timeout);
+delete_topics(Vsn, Topics, Timeout) ->
+  kpro_req_lib:delete_topics(Vsn, Topics, #{timeout => Timeout}).
 
 %% @doc Make a fetch request, If the first arg is a connection pid, call
 %% `brod_kafka_apis:pick_version/2' to resolve version.

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -17,7 +17,8 @@
 %% @doc Help functions to build request messages.
 -module(brod_kafka_request).
 
--export([ delete_topics/3
+-export([ create_topics/3
+        , delete_topics/3
         , fetch/7
         , list_groups/1
         , list_offsets/4
@@ -34,6 +35,7 @@
 -type api() :: brod_kafka_apis:api().
 -type vsn() :: brod_kafka_apis:vsn().
 -type topic() :: brod:topic().
+-type topic_config() :: kpro:struct().
 -type partition() :: brod:partition().
 -type offset() :: brod:offset().
 -type conn() :: kpro:connection().
@@ -53,6 +55,15 @@ produce(MaybePid, Topic, Partition, BatchInput,
                         , ack_timeout => AckTimeout
                         , compression => Compression
                         }).
+
+%% @doc Make a delete_topics request.
+-spec create_topics(vsn() | conn(), [topic_config()], #{timeout => kpro:int32(),
+                    validate_only => boolean()}) -> kpro:req().
+create_topics(Connection, TopicConfigs, RequestConfigs) when is_pid(Connection) ->
+  Vsn = brod_kafka_apis:pick_version(Connection, create_topics),
+  create_topics(Vsn, TopicConfigs, RequestConfigs);
+create_topics(Vsn, TopicConfigs, RequestConfigs) ->
+  kpro_req_lib:create_topics(Vsn, TopicConfigs, RequestConfigs).
 
 %% @doc Make a delete_topics request.
 -spec delete_topics(vsn() | conn(), [topic()], pos_integer()) -> kpro:req().

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -56,7 +56,7 @@ produce(MaybePid, Topic, Partition, BatchInput,
                         , compression => Compression
                         }).
 
-%% @doc Make a delete_topics request.
+%% @doc Make a create_topics request.
 -spec create_topics(vsn() | conn(), [topic_config()], #{timeout => kpro:int32(),
                     validate_only => boolean()}) -> kpro:req().
 create_topics(Connection, TopicConfigs, RequestConfigs) when is_pid(Connection) ->

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -59,7 +59,8 @@ produce(MaybePid, Topic, Partition, BatchInput,
 %% @doc Make a create_topics request.
 -spec create_topics(vsn() | conn(), [topic_config()], #{timeout => kpro:int32(),
                     validate_only => boolean()}) -> kpro:req().
-create_topics(Connection, TopicConfigs, RequestConfigs) when is_pid(Connection) ->
+create_topics(Connection, TopicConfigs, RequestConfigs)
+              when is_pid(Connection) ->
   Vsn = brod_kafka_apis:pick_version(Connection, create_topics),
   create_topics(Vsn, TopicConfigs, RequestConfigs);
 create_topics(Vsn, TopicConfigs, RequestConfigs) ->

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -88,7 +88,8 @@ create_topics(Hosts, TopicConfigs, RequestConfigs) ->
         {ok, kpro:struct()} | {error, any()}.
 create_topics(Hosts, TopicConfigs, RequestConfigs, ConnCfg) ->
   {ok, Conn} = kpro:connect_controller(Hosts, ConnCfg),
-  Request = brod_kafka_request:create_topics(Conn, TopicConfigs, RequestConfigs),
+  Request = brod_kafka_request:create_topics(
+    Conn, TopicConfigs, RequestConfigs),
   request_sync(Conn, Request).
 
 %% @equiv delete_topics(Hosts, Topics, Timeout, [])

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -108,7 +108,7 @@ delete_topics(Hosts, Topics, Timeout, ConnCfg) ->
               fun(Pid) ->
                   Request = brod_kafka_request:delete_topics(
                     Pid, Topics, Timeout),
-                  request_sync(Pid, Request)
+                  request_sync(Pid, Request, Timeout)
               end).
 
 %% @doc Try to connect to any of the bootstrap nodes and fetch metadata

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -74,8 +74,7 @@
 
 %%%_* APIs =====================================================================
 
-%% @doc Try to connect to any of the bootstrap nodes and create topics
-%% for the given topics with configs
+%% @equiv create_topics(Hosts, TopicsConfigs, RequestConfigs, [])
 -spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
                     validate_only => boolean()}) ->
         {ok, kpro:struct()} | {error, any()}.
@@ -88,14 +87,11 @@ create_topics(Hosts, TopicConfigs, RequestConfigs) ->
                     validate_only => boolean()}, conn_config()) ->
         {ok, kpro:struct()} | {error, any()}.
 create_topics(Hosts, TopicConfigs, RequestConfigs, ConnCfg) ->
-  with_conn(Hosts, ConnCfg,
-            fun(Pid) ->
-                Request = brod_kafka_request:create_topics(Pid, TopicConfigs, RequestConfigs),
-                request_sync(Pid, Request)
-            end).
+  {ok, Conn} = kpro:connect_controller(Hosts, ConnCfg),
+  Request = brod_kafka_request:create_topics(Conn, TopicConfigs, RequestConfigs),
+  request_sync(Conn, Request).
 
-%% @doc Try to connect to any of the bootstrap nodes and delete topics
-%% for the given topics with a timeout
+%% @equiv delete_topics(Hosts, Topics, Timeout, [])
 -spec delete_topics([endpoint()], [topic()], pos_integer()) ->
         {ok, kpro:struct()} | {error, any()}.
 delete_topics(Hosts, Topics, Timeout) ->
@@ -106,11 +102,9 @@ delete_topics(Hosts, Topics, Timeout) ->
 -spec delete_topics([endpoint()], [topic()], pos_integer(), conn_config()) ->
         {ok, kpro:struct()} | {error, any()}.
 delete_topics(Hosts, Topics, Timeout, ConnCfg) ->
-  with_conn(Hosts, ConnCfg,
-            fun(Pid) ->
-                Request = brod_kafka_request:delete_topics(Pid, Topics, Timeout),
-                request_sync(Pid, Request)
-            end).
+  {ok, Conn} = kpro:connect_controller(Hosts, ConnCfg),
+  Request = brod_kafka_request:delete_topics(Conn, Topics, Timeout),
+  request_sync(Conn, Request).
 
 %% @doc Try to connect to any of the bootstrap nodes and fetch metadata
 %% for all topics

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -23,6 +23,8 @@
         , assert_topic/1
         , bytes/1
         , describe_groups/3
+        , create_topics/3
+        , create_topics/4
         , delete_topics/3
         , delete_topics/4
         , epoch_ms/0
@@ -63,6 +65,7 @@
 -type connection() :: kpro:connection().
 -type conn_config() :: brod:conn_config().
 -type topic() :: brod:topic().
+-type topic_config() :: kpro:struct().
 -type partition() :: brod:partition().
 -type offset() :: brod:offset().
 -type endpoint() :: brod:endpoint().
@@ -70,6 +73,26 @@
 -type group_id() :: brod:group_id().
 
 %%%_* APIs =====================================================================
+
+%% @doc Try to connect to any of the bootstrap nodes and create topics
+%% for the given topics with configs
+-spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
+                    validate_only => boolean()}) ->
+        {ok, kpro:struct()} | {error, any()}.
+create_topics(Hosts, TopicConfigs, RequestConfigs) ->
+  create_topics(Hosts, TopicConfigs, RequestConfigs, _ConnCfg = []).
+
+%% @doc Try to connect to any of the bootstrap nodes using the given
+%% connection options and create the given topics with configs
+-spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
+                    validate_only => boolean()}, conn_config()) ->
+        {ok, kpro:struct()} | {error, any()}.
+create_topics(Hosts, TopicConfigs, RequestConfigs, ConnCfg) ->
+  with_conn(Hosts, ConnCfg,
+            fun(Pid) ->
+                Request = brod_kafka_request:create_topics(Pid, TopicConfigs, RequestConfigs),
+                request_sync(Pid, Request)
+            end).
 
 %% @doc Try to connect to any of the bootstrap nodes and delete topics
 %% for the given topics with a timeout

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -23,6 +23,8 @@
         , assert_topic/1
         , bytes/1
         , describe_groups/3
+        , delete_topics/3
+        , delete_topics/4
         , epoch_ms/0
         , fetch/4
         , fetch/5
@@ -68,6 +70,24 @@
 -type group_id() :: brod:group_id().
 
 %%%_* APIs =====================================================================
+
+%% @doc Try to connect to any of the bootstrap nodes and delete topics
+%% for the given topics with a timeout
+-spec delete_topics([endpoint()], [topic()], pos_integer()) ->
+        {ok, kpro:struct()} | {error, any()}.
+delete_topics(Hosts, Topics, Timeout) ->
+  delete_topics(Hosts, Topics, Timeout, _ConnCfg = []).
+
+%% @doc Try to connect to any of the bootstrap nodes using the given
+%% connection options and delete the given topics with a timeout
+-spec delete_topics([endpoint()], [topic()], pos_integer(), conn_config()) ->
+        {ok, kpro:struct()} | {error, any()}.
+delete_topics(Hosts, Topics, Timeout, ConnCfg) ->
+  with_conn(Hosts, ConnCfg,
+            fun(Pid) ->
+                Request = brod_kafka_request:delete_topics(Pid, Topics, Timeout),
+                request_sync(Pid, Request)
+            end).
 
 %% @doc Try to connect to any of the bootstrap nodes and fetch metadata
 %% for all topics

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -81,7 +81,7 @@
 create_topics(Hosts, TopicConfigs, RequestConfigs) ->
   create_topics(Hosts, TopicConfigs, RequestConfigs, _ConnCfg = []).
 
-%% @doc Try to connect to any of the bootstrap nodes using the given
+%% @doc Try to connect to the controller node using the given
 %% connection options and create the given topics with configs
 -spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),
                     validate_only => boolean()}, conn_config()) ->
@@ -99,7 +99,7 @@ create_topics(Hosts, TopicConfigs, RequestConfigs, ConnCfg) ->
 delete_topics(Hosts, Topics, Timeout) ->
   delete_topics(Hosts, Topics, Timeout, _ConnCfg = []).
 
-%% @doc Try to connect to any of the bootstrap nodes using the given
+%% @doc Try to connect to the controller node using the given
 %% connection options and delete the given topics with a timeout
 -spec delete_topics([endpoint()], [topic()], pos_integer(), conn_config()) ->
         {ok, kpro:struct()} | {error, any()}.

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -87,11 +87,12 @@ create_topics(Hosts, TopicConfigs, RequestConfigs) ->
                     validate_only => boolean()}, conn_config()) ->
         {ok, kpro:struct()} | {error, any()}.
 create_topics(Hosts, TopicConfigs, RequestConfigs, ConnCfg) ->
-  {ok, Conn} = kpro:connect_controller(Hosts, ConnCfg),
-  Request = brod_kafka_request:create_topics(
-    Conn, TopicConfigs, RequestConfigs),
-  request_sync(Conn, Request).
-
+  with_conn(kpro:connect_controller(Hosts, ConnCfg),
+            fun(Pid) ->
+                Request = brod_kafka_request:create_topics(
+                  Pid, TopicConfigs, RequestConfigs),
+                request_sync(Pid, Request)
+            end).
 %% @equiv delete_topics(Hosts, Topics, Timeout, [])
 -spec delete_topics([endpoint()], [topic()], pos_integer()) ->
         {ok, kpro:struct()} | {error, any()}.
@@ -103,9 +104,12 @@ delete_topics(Hosts, Topics, Timeout) ->
 -spec delete_topics([endpoint()], [topic()], pos_integer(), conn_config()) ->
         {ok, kpro:struct()} | {error, any()}.
 delete_topics(Hosts, Topics, Timeout, ConnCfg) ->
-  {ok, Conn} = kpro:connect_controller(Hosts, ConnCfg),
-  Request = brod_kafka_request:delete_topics(Conn, Topics, Timeout),
-  request_sync(Conn, Request).
+  with_conn(kpro:connect_controller(Hosts, ConnCfg),
+              fun(Pid) ->
+                  Request = brod_kafka_request:delete_topics(
+                    Pid, Topics, Timeout),
+                  request_sync(Pid, Request)
+              end).
 
 %% @doc Try to connect to any of the bootstrap nodes and fetch metadata
 %% for all topics

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -33,7 +33,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
--define(HOSTS, [{"localhost", 9092}, {"localhost", 9192}]).
+-define(HOSTS, [{"localhost", 9092}]).
 -define(TOPIC, list_to_binary(atom_to_list(?MODULE))).
 -define(TIMEOUT, 50000).
 

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -31,7 +31,7 @@
         ]).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("eunit/include/eunit.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -define(HOSTS, [{"localhost", 9092}, {"localhost", 9192}]).
 -define(TOPIC, list_to_binary(atom_to_list(?MODULE))).

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -35,7 +35,7 @@
 
 -define(HOSTS, [{"localhost", 9092}]).
 -define(TOPIC, list_to_binary(atom_to_list(?MODULE))).
--define(TIMEOUT, 200000).
+-define(TIMEOUT, 280000).
 
 %%%_* ct callbacks =============================================================
 
@@ -68,9 +68,7 @@ t_create_topics(Config) when is_list(Config) ->
   ],
   ?assertEqual(ok,
     brod:create_topics(?HOSTS, TopicConfig, #{timeout => ?TIMEOUT},
-      #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})),
-  ?assertEqual(ok, brod:delete_topics(?HOSTS, [Topic], ?TIMEOUT,
-    #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
+      #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
 
 t_delete_topics(Config) when is_list(Config) ->
   ?assertEqual(ok, brod:delete_topics(?HOSTS, [?TOPIC], ?TIMEOUT,

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -66,14 +66,20 @@ t_create_topics(Config) when is_list(Config) ->
       topic => Topic
     }
   ],
-  ?assertEqual(ok, brod:create_topics(?HOSTS, TopicConfig, #{timeout => ?TIMEOUT})),
-  ?assertEqual(ok, brod:delete_topics(?HOSTS, [Topic], ?TIMEOUT)).
+  ?assertEqual(ok,
+    brod:create_topics(?HOSTS, TopicConfig, #{timeout => ?TIMEOUT},
+      #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})),
+  ?assertEqual(ok, brod:delete_topics(?HOSTS, [Topic], ?TIMEOUT,
+    #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
 
 t_delete_topics(Config) when is_list(Config) ->
-  ?assertEqual(ok, brod:delete_topics(?HOSTS, [?TOPIC], ?TIMEOUT)).
+  ?assertEqual(ok, brod:delete_topics(?HOSTS, [?TOPIC], ?TIMEOUT,
+    #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
 
 t_delete_topics_not_found(Config) when is_list(Config) ->
-  ?assertEqual({error, unknown_topic_or_partition}, brod:delete_topics(?HOSTS, [<<"no-such-topic">>], ?TIMEOUT)).
+  ?assertEqual({error, unknown_topic_or_partition},
+    brod:delete_topics(?HOSTS, [<<"no-such-topic">>], ?TIMEOUT,
+      #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -32,13 +32,10 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include("brod_int.hrl").
 
 -define(HOSTS, [{"localhost", 9092}, {"localhost", 9192}]).
 -define(TOPIC, list_to_binary(atom_to_list(?MODULE))).
--define(TIMEOUT, 1000).
-
--define(config(Name), proplists:get_value(Name, Config)).
+-define(TIMEOUT, 50000).
 
 %%%_* ct callbacks =============================================================
 

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -42,7 +42,11 @@
 suite() -> [{timetrap, {minutes, 5}}].
 
 init_per_suite(Config) ->
-  Config.
+  case os:getenv("KAFKA_VERSION") of
+    "0.9" -> {skip,
+      "The given Kafka test image does not have support for these apis"};
+    _ -> Config
+  end.
 
 end_per_suite(_Config) ->
   ok.

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -35,11 +35,11 @@
 
 -define(HOSTS, [{"localhost", 9092}]).
 -define(TOPIC, list_to_binary(atom_to_list(?MODULE))).
--define(TIMEOUT, 50000).
+-define(TIMEOUT, 200000).
 
 %%%_* ct callbacks =============================================================
 
-suite() -> [{timetrap, {seconds, 30}}].
+suite() -> [{timetrap, {minutes, 5}}].
 
 init_per_suite(Config) ->
   Config.

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -1,0 +1,85 @@
+%%%
+%%%   Copyright (c) 2019, Klarna Bank AB (publ)
+%%%
+%%%   Licensed under the Apache License, Version 2.0 (the "License");
+%%%   you may not use this file except in compliance with the License.
+%%%   You may obtain a copy of the License at
+%%%
+%%%       http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%%   Unless required by applicable law or agreed to in writing, software
+%%%   distributed under the License is distributed on an "AS IS" BASIS,
+%%%   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%%   See the License for the specific language governing permissions and
+%%%   limitations under the License.
+%%%
+
+%% @private
+-module(brod_SUITE).
+
+%% Test framework
+-export([ init_per_suite/1
+        , end_per_suite/1
+        , all/0
+        , suite/0
+        ]).
+
+%% Test cases
+-export([ t_create_topics/1
+        , t_delete_topics/1
+        , t_delete_topics_not_found/1
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("brod_int.hrl").
+
+-define(HOSTS, [{"localhost", 9092}, {"localhost", 9192}]).
+-define(TOPIC, list_to_binary(atom_to_list(?MODULE))).
+-define(TIMEOUT, 1000).
+
+-define(config(Name), proplists:get_value(Name, Config)).
+
+%%%_* ct callbacks =============================================================
+
+suite() -> [{timetrap, {seconds, 30}}].
+
+init_per_suite(Config) ->
+  Config.
+
+end_per_suite(_Config) ->
+  ok.
+
+all() -> [F || {F, _A} <- module_info(exports),
+                  case atom_to_list(F) of
+                    "t_" ++ _ -> true;
+                    _         -> false
+                  end].
+
+%%%_* Test functions ===========================================================
+
+t_create_topics(Config) when is_list(Config) ->
+  Topic = <<"test-create-topic">>,
+  TopicConfig = [
+    #{
+      config_entries => [],
+      num_partitions => 1,
+      replica_assignment => [],
+      replication_factor => 1,
+      topic => Topic
+    }
+  ],
+  ?assertEqual(ok, brod:create_topics(?HOSTS, TopicConfig, #{timeout => ?TIMEOUT})),
+  ?assertEqual(ok, brod:delete_topics(?HOSTS, [Topic], ?TIMEOUT)).
+
+t_delete_topics(Config) when is_list(Config) ->
+  ?assertEqual(ok, brod:delete_topics(?HOSTS, [?TOPIC], ?TIMEOUT)).
+
+t_delete_topics_not_found(Config) when is_list(Config) ->
+  ?assertEqual({error, unknown_topic_or_partition}, brod:delete_topics(?HOSTS, [<<"no-such-topic">>], ?TIMEOUT)).
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -68,16 +68,16 @@ t_create_topics(Config) when is_list(Config) ->
   ],
   ?assertEqual(ok,
     brod:create_topics(?HOSTS, TopicConfig, #{timeout => ?TIMEOUT},
-      #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
+      #{connect_timeout => ?TIMEOUT})).
 
 t_delete_topics(Config) when is_list(Config) ->
   ?assertEqual(ok, brod:delete_topics(?HOSTS, [?TOPIC], ?TIMEOUT,
-    #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
+    #{connect_timeout => ?TIMEOUT})).
 
 t_delete_topics_not_found(Config) when is_list(Config) ->
   ?assertEqual({error, unknown_topic_or_partition},
     brod:delete_topics(?HOSTS, [<<"no-such-topic">>], ?TIMEOUT,
-      #{connect_timeout => ?TIMEOUT, request_timeout => ?TIMEOUT})).
+      #{connect_timeout => ?TIMEOUT})).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:


### PR DESCRIPTION
I needed create and delete topics for a project I'm working on, so I added them in.
I've tested them from elixir with the following:

```elixir
topic_config = [
  %{
    config_entries: [],
    num_partitions: 2,
    replica_assignment: [],
    replication_factor: 1,
    topic: "test_create_topic"
  }
]
:brod.create_topics([{'localhost', 9092}], topic_config, %{})
:brod.delete_topics([{'localhost', 9092}], ["test_create_topic"], 1_000)
```

and they both worked. Let me know if you want to me to try to add tests or if there's any other issues. Apologies for the readme space removal (hopefully that's not an issue). 

I'm mostly delegating to your kafka_protocol library which does all the work. I wasn't sure about the API version support so I went with `{0, 0}` but am willing to change it if that's incorrect.

Thanks for making brod!