### PR TITLE
Handle undefined fetcher in fold loop exception

### DIFF
--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -612,6 +612,7 @@ do_acc(Spawn, Fetcher, Offset, Acc, Fun, [Msg | Rest], End, Count) ->
       erlang:raise(C, E, Stack)
   end.
 
+kill_fetcher(undefined) -> ok;
 kill_fetcher({Pid, Mref}) ->
   exit(Pid, kill),
   receive


### PR DESCRIPTION
Prior to this commit, fold loop may crash if there
is an exception in message handler callback when
processing the last batch (i.e. when there is no
running fetcher for the next batch), kill_fetcher
function may crash on 'undefined' clause