### PR TITLE
Improve testbed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _rel/
 *.log
 relx
 docker/
+TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,27 +42,19 @@ script:
     if [ $OTP_VSN -eq 22 ]; then
       # run dialyzer only in otp 22
       rebar3 dialyzer
-      # test against kafka 0.9 in otp 22
       export KAFKA_VERSION="2.2"
     fi
     if [ $OTP_VSN -eq 21 ]; then
-      # test against kafka 2.2 in otp 21
       export KAFKA_VERSION="2.2"
     fi
     if [ $OTP_VSN -eq 20 ]; then
-      # test against kafka 0.10 in otp 20
       export KAFKA_VERSION="0.11"
     fi
     if [ $OTP_VSN -eq 19 ]; then
-      # test against kafka 0.11 in otp 19
       export KAFKA_VERSION="0.10"
     fi
     make test-env
     _build/brod_cli/rel/brod/bin/brod meta -b localhost -L
-    make it
-    # final full test against kafka 1.1
-    export KAFKA_VERSION="1.1"
-    make test-env
     make t
     make cover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
       # run dialyzer only in otp 22
       rebar3 dialyzer
       # test against kafka 0.9 in otp 22
-      export KAFKA_VERSION="0.9"
+      export KAFKA_VERSION="2.2"
     fi
     if [ $OTP_VSN -eq 21 ]; then
       # test against kafka 2.2 in otp 21
@@ -51,11 +51,11 @@ script:
     fi
     if [ $OTP_VSN -eq 20 ]; then
       # test against kafka 0.10 in otp 20
-      export KAFKA_VERSION="0.10"
+      export KAFKA_VERSION="0.11"
     fi
     if [ $OTP_VSN -eq 19 ]; then
       # test against kafka 0.11 in otp 19
-      export KAFKA_VERSION="0.11"
+      export KAFKA_VERSION="0.10"
     fi
     make test-env
     _build/brod_cli/rel/brod/bin/brod meta -b localhost -L

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,6 @@ hex-publish: distclean
 ## tests that require kafka running at localhost
 INTEGRATION_CTS = brod_cg_commits brod_client brod_compression brod_consumer brod_producer brod_group_subscriber brod_topic_subscriber brod
 
-## integration tests
-it: ut $(INTEGRATION_CTS:%=it-%)
-
-$(INTEGRATION_CTS:%=it-%):
-	@rebar3 ct -v --suite=test/$(subst it-,,$@)_SUITE --cover_export_name $@-$(KAFKA_VERSION)
-
 ## build escript and a releas, and copy escript to release bin dir
 brod-cli:
 	@rebar3 as brod_cli do compile,escriptize,release

--- a/rebar.config
+++ b/rebar.config
@@ -14,4 +14,4 @@
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
-{ct_readable, false}.
+%{ct_readable, false}.

--- a/rebar.config
+++ b/rebar.config
@@ -14,3 +14,4 @@
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
+{ct_readable, false}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -18,7 +18,7 @@ Profiles =
                         ]}
              ]}]},
     {test, [
-      {deps, [meck, proper, jsone, DocoptDep, Snabbkaffe]},
+      {deps, [meck, proper, jsone, DocoptDep, Snabbkaffe, docker_compose_cth]},
       {erl_opts, [{d, build_brod_cli}]}
     ]}
   ]},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -18,7 +18,7 @@ Profiles =
                         ]}
              ]}]},
     {test, [
-      {deps, [meck, proper, jsone, DocoptDep, Snabbkaffe, docker_compose_cth]},
+      {deps, [meck, proper, jsone, DocoptDep, Snabbkaffe]},
       {erl_opts, [{d, build_brod_cli}]}
     ]}
   ]},

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -54,7 +54,6 @@ create_topic "brod_SUITE"
 create_topic "brod-client-SUITE-topic"
 create_topic "brod_consumer_SUITE"
 create_topic "brod_producer_SUITE"            2
-create_topic "brod_topic_subscriber_SUITE"    3 2
 create_topic "brod-group-coordinator"         3 2
 create_topic "brod-demo-topic-subscriber"     3 2
 create_topic "brod-demo-group-subscriber-koc" 3 2

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -eu
 
+docker ps > /dev/null || {
+    echo "You must be a member of docker group to run this script"
+    exit 1
+}
+
 VERSION=${KAFKA_VERSION:-1.1}
 if [ -z $VERSION ]; then VERSION=$1; fi
 
@@ -23,11 +28,11 @@ export KAFKA_VERSION=$VERSION
 
 TD="$(cd "$(dirname "$0")" && pwd)"
 
-sudo KAFKA_VERSION=${KAFKA_VERSION} docker-compose -f $TD/docker-compose.yml down || true
-sudo KAFKA_VERSION=${KAFKA_VERSION} docker-compose -f $TD/docker-compose.yml up -d
+docker-compose -f $TD/docker-compose.yml down || true
+docker-compose -f $TD/docker-compose.yml up -d
 
 n=0
-while [ "$(sudo docker exec kafka-1 bash -c '/opt/kafka/bin/kafka-topics.sh --zookeeper localhost --list')" != '' ]; do
+while [ "$(docker exec kafka-1 bash -c '/opt/kafka/bin/kafka-topics.sh --zookeeper localhost --list')" != '' ]; do
   if [ $n -gt 4 ]; then
     echo "timeout waiting for kakfa_1"
     exit 1
@@ -41,7 +46,7 @@ function create_topic {
   PARTITIONS="${2:-1}"
   REPLICAS="${3:-1}"
   CMD="/opt/kafka/bin/kafka-topics.sh --zookeeper localhost --create --partitions $PARTITIONS --replication-factor $REPLICAS --topic $TOPIC_NAME --config min.insync.replicas=1"
-  sudo docker exec kafka-1 bash -c "$CMD"
+  docker exec kafka-1 bash -c "$CMD"
 }
 
 create_topic "dummy" || true
@@ -51,10 +56,6 @@ create_topic "brod_consumer_SUITE"
 create_topic "brod_producer_SUITE"            2
 create_topic "brod_topic_subscriber_SUITE"    3 2
 create_topic "brod-group-coordinator"         3 2
-create_topic "brod-group-subscriber-1"        3 2
-create_topic "brod-group-subscriber-2"        3 2
-create_topic "brod-group-subscriber-3"        3 2
-create_topic "brod-group-subscriber-4"
 create_topic "brod-demo-topic-subscriber"     3 2
 create_topic "brod-demo-group-subscriber-koc" 3 2
 create_topic "brod-demo-group-subscriber-loc" 3 2
@@ -68,9 +69,9 @@ else
   MAYBE_NEW_CONSUMER="--new-consumer"
 fi
 # this is to warm-up kafka group coordinator for deterministic in tests
-sudo docker exec kafka-1 /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 $MAYBE_NEW_CONSUMER --group test-group --describe > /dev/null 2>&1
+docker exec kafka-1 /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 $MAYBE_NEW_CONSUMER --group test-group --describe > /dev/null 2>&1
 
 # for kafka 0.11 or later, add sasl-scram test credentials
 if [[ "$KAFKA_VERSION" != 0.9* ]] && [[ "$KAFKA_VERSION" != 0.10* ]]; then
-  sudo docker exec kafka-1 /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[iterations=8192,password=ecila],SCRAM-SHA-512=[password=ecila]' --entity-type users --entity-name alice
+  docker exec kafka-1 /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[iterations=8192,password=ecila],SCRAM-SHA-512=[password=ecila]' --entity-type users --entity-name alice
 fi

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -9,8 +9,6 @@ VERSION=${KAFKA_VERSION:-1.1}
 if [ -z $VERSION ]; then VERSION=$1; fi
 
 case $VERSION in
-  0.9*)
-    VERSION="0.9";;
   0.10*)
     VERSION="0.10";;
   0.11*)

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -517,7 +517,7 @@ start_subscriber(Config, Topics, InitArgs) ->
                           , {sleep_timeout, 0}
                           , {max_wait_time, 100}
                           , {partition_restart_delay_seconds, 1}
-                          , {begin_offset, earliest}
+                          , {begin_offset, 0}
                           ],
   GroupConfig = proplists:get_value( group_subscriber_config
                                    , Config
@@ -552,7 +552,6 @@ start_subscriber(Config, Topics, GroupConfig, ConsumerConfig, InitArgs) ->
                                          GroupConfig, ConsumerConfig,
                                          ?MODULE, InitArgs)
     end,
-  timer:sleep(10000),
   {ok, SubscriberPid}.
 
 meck_subscribe_unsubscribe() ->

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -103,7 +103,7 @@ end_per_group(_Group, _Config) ->
 
 common_init_per_testcase(Case, Config0) ->
   Config = kafka_test_helper:common_init_per_testcase(?MODULE, Case, Config0),
-  BootstrapHosts = [{"localhost", 9092}],
+  BootstrapHosts = bootstrap_hosts(),
   ClientConfig   = client_config(),
   ok = brod:start_client(BootstrapHosts, ?CLIENT_ID, ClientConfig),
   Config.
@@ -497,12 +497,6 @@ handled_messages(Trace) ->
 rand_uniform(Max) ->
   {_, _, Micro} = os:timestamp(),
   Micro rem Max.
-
-client_config() ->
-  case os:getenv("KAFKA_VERSION") of
-    "0.9" ++ _ -> [{query_api_versions, false}];
-    _ -> []
-  end.
 
 payloads(Config) ->
   [<<I>> || I <- lists:seq(1, ?config(max_seqno))].

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -248,9 +248,9 @@ t_async_acks(Config) when is_list(Config) ->
      #{ timeout => Timeout },
      %% Run stage:
      begin
-       {ok, SubscriberPid} = start_subscriber(Config, [Topic], InitArgs),
        %% Produce some messages into the topic:
        {_, L} = produce_payloads(Topic, Partition, Config),
+       {ok, SubscriberPid} = start_subscriber(Config, [Topic], InitArgs),
        %% And ack/commit them asynchronously:
        [begin
           {ok, #{offset := Offset}} = ?wait_message(Topic, Partition, I, _),
@@ -360,11 +360,11 @@ t_2_members_one_partition(Config) when is_list(Config) ->
   ?check_trace(
      %% Run stage:
      begin
+       %% Send messages:
+       {LastOffset, L} = produce_payloads(Topic, 0, Config),
        %% Start two subscribers competing for the partition:
        {ok, SubscriberPid1} = start_subscriber(Config, [Topic], InitArgs),
        {ok, SubscriberPid2} = start_subscriber(Config, [Topic], InitArgs),
-       %% Send messages:
-       {LastOffset, L} = produce_payloads(Topic, 0, Config),
        ?wait_message(_, _, _, LastOffset),
        L
      end,

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -504,6 +504,7 @@ payloads(Config) ->
 %% Produce binaries to the topic and return offset of the last message:
 produce_payloads(Topic, Partition, Config) ->
   Payloads = payloads(Config),
+  ?log(notice, "Producing payloads to ~p", [{Topic, Partition}]),
   [produce({Topic, Partition}, I) + 1 || I <- payloads(Config)],
   Payloads.
 

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -109,6 +109,7 @@ common_init_per_testcase(Case, Config0) ->
   Config.
 
 common_end_per_testcase(Case, Config) ->
+  brod:stop_client(?CLIENT_ID),
   kafka_test_helper:common_end_per_testcase(Case, Config).
 
 %%%_* Group subscriber callbacks ===============================================
@@ -522,6 +523,7 @@ start_subscriber(Config, Topics, InitArgs) ->
                           , {sleep_timeout, 0}
                           , {max_wait_time, 100}
                           , {partition_restart_delay_seconds, 1}
+                          , {begin_offset, earliest}
                           ],
   GroupConfig = proplists:get_value( group_subscriber_config
                                    , Config
@@ -535,7 +537,7 @@ start_subscriber(Config, Topics, InitArgs) ->
 
 start_subscriber(Config, Topics, GroupConfig, ConsumerConfig, InitArgs) ->
   GroupId = case ?config(group_id) of
-              undefined -> ?GROUP_ID;
+              undefined -> ?group_id;
               A         -> A
             end,
   {ok, SubscriberPid} =

--- a/test/brod_group_subscriber_test.hrl
+++ b/test/brod_group_subscriber_test.hrl
@@ -10,7 +10,6 @@
 -define(MSG(Ref, Pid, Topic, Partition, Offset, Value),
         {Ref, Pid, Topic, Partition, Offset, Value}).
 
--define(CLIENT_ID, ?MODULE).
 -define(TOPIC1, <<"brod-group-subscriber-1">>).
 -define(TOPIC2, <<"brod-group-subscriber-2">>).
 -define(TOPIC3, <<"brod-group-subscriber-3">>).

--- a/test/brod_test_macros.hrl
+++ b/test/brod_test_macros.hrl
@@ -10,18 +10,17 @@
 %% Macros
 %%====================================================================
 
--define(CLIENT_ID, brod_test_client).
 -define(KAFKA_HOST, "localhost").
 -define(KAFKA_PORT, 9092).
 
 -define(topic(TestCase, N),
         list_to_binary(atom_to_list(TestCase) ++ integer_to_list(N))).
--define(topic(TestCase), ?topic(TestCase, 1)).
--define(topic, ?topic(?FUNCTION_NAME)).
+-define(topic(N), ?topic(?FUNCTION_NAME, N)).
+-define(topic, ?topic(1)).
 
--define(group_id(TestCase),
+-define(group_id(TestCase, N),
         list_to_binary(atom_to_list(TestCase) ++ "_grp" ++ integer_to_list(N))).
--define(group_id(TestCase), ?group_id(TestCase, 1)).
--define(group_id, ?group_id(?FUNCTION_NAME)).
+-define(group_id(N), ?group_id(?FUNCTION_NAME, N)).
+-define(group_id, ?group_id(1)).
 
 -endif.

--- a/test/brod_test_macros.hrl
+++ b/test/brod_test_macros.hrl
@@ -10,6 +10,8 @@
 %% Macros
 %%====================================================================
 
+-define(TEST_CLIENT_ID, brod_test_client).
+
 -define(KAFKA_HOST, "localhost").
 -define(KAFKA_PORT, 9092).
 

--- a/test/brod_test_macros.hrl
+++ b/test/brod_test_macros.hrl
@@ -1,0 +1,27 @@
+-ifndef(BROD_TEST_MACROS_HRL).
+-define(BROD_TEST_MACROS_HRL, true).
+
+-include_lib("kafka_protocol/include/kpro.hrl").
+-include_lib("hut/include/hut.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%====================================================================
+%% Macros
+%%====================================================================
+
+-define(CLIENT_ID, brod_test_client).
+-define(KAFKA_HOST, "localhost").
+-define(KAFKA_PORT, 9092).
+
+-define(topic(TestCase, N),
+        list_to_binary(atom_to_list(TestCase) ++ integer_to_list(N))).
+-define(topic(TestCase), ?topic(TestCase, 1)).
+-define(topic, ?topic(?FUNCTION_NAME)).
+
+-define(group_id(TestCase),
+        list_to_binary(atom_to_list(TestCase) ++ "_grp" ++ integer_to_list(N))).
+-define(group_id(TestCase), ?group_id(TestCase, 1)).
+-define(group_id, ?group_id(?FUNCTION_NAME)).
+
+-endif.

--- a/test/brod_test_setup.hrl
+++ b/test/brod_test_setup.hrl
@@ -1,0 +1,17 @@
+-ifndef(KAFKA_CT_SETUP_HRL).
+-define(KAFKA_CT_SETUP_HRL, true).
+
+-import(kafka_test_helper, [ produce/2
+                           , produce/3
+                           , produce/4
+                           , create_topic/2
+                           , get_acked_offsets/2
+                           , check_committed_offsets/2
+                           , wait_n_messages/2
+                           , wait_n_messages/3
+                           , consumer_config/0
+                           ]).
+
+-include("brod_test_macros.hrl").
+
+-endif.

--- a/test/brod_test_setup.hrl
+++ b/test/brod_test_setup.hrl
@@ -10,6 +10,8 @@
                            , wait_n_messages/2
                            , wait_n_messages/3
                            , consumer_config/0
+                           , client_config/0
+                           , bootstrap_hosts/0
                            ]).
 
 -include("brod_test_macros.hrl").

--- a/test/brod_test_setup.hrl
+++ b/test/brod_test_setup.hrl
@@ -4,6 +4,8 @@
 -import(kafka_test_helper, [ produce/2
                            , produce/3
                            , produce/4
+                           , payloads/1
+                           , produce_payloads/3
                            , create_topic/2
                            , get_acked_offsets/2
                            , check_committed_offsets/2

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -12,12 +12,13 @@
         , wait_n_messages/3
         , wait_n_messages/2
         , consumer_config/0
+        , client_config/0
+        , bootstrap_hosts/0
         ]).
 
 -include("brod_test_macros.hrl").
 
 init_per_suite(Config) ->
-  {ok, _} = application:ensure_all_started(brod),
   [ {proper_timeout, 10000}
   | Config].
 
@@ -62,6 +63,12 @@ produce({Topic, Partition}, Key, Value, Headers) ->
                                              }]
                                          ),
   Offset.
+
+client_config() ->
+  case os:getenv("KAFKA_VERSION") of
+    "0.9" ++ _ -> [{query_api_versions, false}];
+    _          -> []
+  end.
 
 prepare_topic(Topic) when is_binary(Topic) ->
   prepare_topic({Topic, 1});

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -158,7 +158,7 @@ consumer_config() ->
   %% time from failure suites:
   [ {max_wait_time, 500}
   , {sleep_timeout, 100}
-  , {max_bytes, 1}
+  , {begin_offset, 0}
   ].
 
 bootstrap_hosts() ->

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -30,7 +30,6 @@ common_init_per_testcase(Module, Case, Config) ->
   %% By default name of the test topic is equal to the name of
   %% testcase.
   {ok, _} = application:ensure_all_started(brod),
-  catch brod:stop_client(?TEST_CLIENT_ID),
   ok = brod:start_client(bootstrap_hosts(), ?TEST_CLIENT_ID, client_config()),
   Topics = try Module:Case(topics) of
                L -> L
@@ -41,6 +40,7 @@ common_init_per_testcase(Module, Case, Config) ->
   Config.
 
 common_end_per_testcase(Case, Config) ->
+  catch brod:stop_client(?TEST_CLIENT_ID),
   ok.
 
 produce(TopicPartition, Value) ->

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -65,6 +65,7 @@ produce({Topic, Partition}, Key, Value, Headers) ->
                                              , headers => Headers
                                              }]
                                          ),
+  ?log(notice, "Produced at ~p ~p, offset: ~p", [Topic, Partition, Offset]),
   Offset.
 
 payloads(Config) ->
@@ -75,7 +76,8 @@ payloads(Config) ->
 produce_payloads(Topic, Partition, Config) ->
   Payloads = payloads(Config),
   ?log(notice, "Producing payloads to ~p", [{Topic, Partition}]),
-  LastOffset = lists:last([produce({Topic, Partition}, I) + 1 || I <- payloads(Config)]),
+  L = [produce({Topic, Partition}, I) + 1 || I <- payloads(Config)],
+  LastOffset = lists:last(L),
   {LastOffset, Payloads}.
 
 client_config() ->
@@ -114,7 +116,7 @@ exec_in_kafka_container(FMT, Args) ->
 collect_port_output(Port, CMD) ->
   receive
     {Port, {data, Str}} ->
-      ?log(info, "~s", [Str]),
+      ?log(notice, "~s", [Str]),
       collect_port_output(Port, CMD);
     {Port, {exit_status, ExitStatus}} ->
       ExitStatus

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -17,6 +17,7 @@
         ]).
 
 -include("brod_test_macros.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 init_per_suite(Config) ->
   [ {proper_timeout, 10000}
@@ -28,7 +29,7 @@ common_init_per_testcase(Module, Case, Config) ->
   %% testcase.
   {ok, _} = application:ensure_all_started(brod),
   catch brod:stop_client(?TEST_CLIENT_ID),
-  ok = brod:start_client(bootstrap_hosts(), ?TEST_CLIENT_ID, []),
+  ok = brod:start_client(bootstrap_hosts(), ?TEST_CLIENT_ID, client_config()),
   Topics = try Module:Case(topics) of
                L -> L
            catch

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -26,10 +26,8 @@ common_init_per_testcase(Module, Case, Config) ->
   %% By default name of the test topic is equal to the name of
   %% testcase.
   {ok, _} = application:ensure_all_started(brod),
-  case brod:start_client(bootstrap_hosts(), ?TEST_CLIENT_ID, []) of
-    ok -> ok;
-    {error, already_started} -> ok
-  end,
+  catch brod:stop_client(?TEST_CLIENT_ID),
+  ok = brod:start_client(bootstrap_hosts(), ?TEST_CLIENT_ID, []),
   Topics = try Module:Case(topics) of
                L -> L
            catch
@@ -39,7 +37,7 @@ common_init_per_testcase(Module, Case, Config) ->
   Config.
 
 common_end_per_testcase(Case, Config) ->
-  brod:stop_client(?TEST_CLIENT_ID).
+  ok.
 
 produce(TopicPartition, Value) ->
   produce(TopicPartition, <<>>, Value).

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -1,0 +1,161 @@
+-module(kafka_test_helper).
+
+-export([ init_per_suite/1
+        , common_init_per_testcase/3
+        , common_end_per_testcase/2
+        , produce/2
+        , produce/3
+        , produce/4
+        , create_topic/2
+        , get_acked_offsets/1
+        , check_committed_offsets/2
+        , wait_n_messages/3
+        , wait_n_messages/2
+        , wait_for_port/2
+        , consumer_config/0
+        ]).
+
+-include("brod_test_macros.hrl").
+
+init_per_suite(Config) ->
+  {ok, CWD} = file:get_cwd(),
+  {ok, _} = application:ensure_all_started(brod),
+  [ {proper_timeout, 10000}
+  , {ct_hooks, [docker_compose_cth]}
+  | Config].
+
+common_init_per_testcase(Module, Case, Config) ->
+  %% Create a client and a producer for putting test data to Kafka.
+  %% By default name of the test topic is equal to the name of
+  %% testcase.
+  Topics = try Module:Case(topics) of
+               L -> L
+           catch
+             _:_ -> [{?topic(Case), 1}]
+           end,
+  prepare_topics(Topics),
+  Config.
+
+common_end_per_testcase(Case, Config) ->
+  ok = brod:stop_client(?CLIENT_ID),
+  application:stop(brod).
+
+produce(TopicPartition, Value) ->
+  produce(TopicPartition, <<>>, Value).
+
+produce(TopicPartition, Key, Value) ->
+  produce(TopicPartition, Key, Value, []).
+
+produce({Topic, Partition}, Key, Value, Headers) ->
+  ?tp(test_topic_produce, #{ topic     => Topic
+                           , partition => Partition
+                           , key       => Key
+                           , value     => Value
+                           , headers   => Headers
+                           }),
+  {ok, Offset} = brod:produce_sync_offset( ?CLIENT_ID
+                                         , Topic
+                                         , Partition
+                                         , <<>>
+                                         , [#{value => Value, key => Key, headers => Headers}]
+                                         ),
+  Offset.
+
+prepare_topic(Topic) when is_binary(Topic) ->
+  prepare_topic({Topic, 1});
+prepare_topic({Topic, NumPartitions}) ->
+  ClientId       = ?CLIENT_ID,
+  BootstrapHosts = [{?KAFKA_HOST, ?KAFKA_PORT}],
+  ok = create_topic(Topic, NumPartitions),
+  ok = brod:start_client(BootstrapHosts, ClientId, []),
+  ok = brod:start_producer(ClientId, Topic, _ProducerConfig = []).
+
+create_topic(Name, NumPartitions) ->
+  ?log(info, "Creating Kafka topic: ~p", [Name]),
+  ConfigEntries = [ {config_name, "max.message.bytes"}
+                  , {config_value, "20485760"} % ~20 MB
+                  ],
+  TopicFields = [ {topic, Name}
+                , {num_partitions, NumPartitions}
+                , {replication_factor, 1}
+                , {replica_assignment, []}
+                , {config_entries, [ConfigEntries]}
+                ],
+  Req = kpro_req_lib:create_topics( 0
+                                  , [TopicFields]
+                                  , #{timeout => 1000}
+                                  ),
+  ?retry(_PollInterval = 2000, _NRetries = 120,
+         begin
+           {ok, Conn} = kpro:connect_any([{?KAFKA_HOST, ?KAFKA_PORT}], []),
+           try
+             {ok, Result} = kpro:request_sync(Conn, Req, 1000),
+             ?log(info, "KPRO response: ~p", [Result]),
+             #{topic_errors := [#{error_code := TopicError}]} = Result#kpro_rsp.msg,
+             case TopicError of
+               no_error -> ok;
+               topic_already_exists -> ok
+             end
+           after
+             kpro:close_connection(Conn)
+           end
+         end),
+  ok.
+
+-spec get_acked_offsets(brod:group_id()) -> #{brod:partition() => brod:offset()}.
+get_acked_offsets(GroupId) ->
+  {ok, [#{partition_responses := Resp}]} =
+    brod:fetch_committed_offsets(?CLIENT_ID, GroupId),
+  Fun = fun(#{partition := P, offset := O}, Acc) ->
+            Acc #{P => O}
+        end,
+  lists:foldl(Fun, #{}, Resp).
+
+%% Validate offsets committed to Kafka:
+check_committed_offsets(GroupId, Offsets) ->
+  CommittedOffsets = get_acked_offsets(GroupId),
+  lists:foreach( fun({TopicPartition, Offset}) ->
+                     %% Explanation for + 1: brod's `roundrobin_v2'
+                     %% protocol keeps _first unprocessed_ offset
+                     %% rather than _last processed_. And this is
+                     %% confusing.
+                     ?assertEqual( Offset + 1
+                                 , maps:get(TopicPartition, CommittedOffsets, undefined)
+                                 )
+                 end
+               , Offsets
+               ).
+
+%% Wait until total number of messages processed by a consumer group
+%% becomes equal to the expected value
+wait_n_messages(TestGroupId, Expected, NRetries) ->
+  ?retry(1000, NRetries,
+         begin
+           Offsets = get_acked_offsets(TestGroupId),
+           NMessages = lists:sum(maps:values(Offsets)),
+           ?log( notice
+               , "Number of messages processed by consumer group: ~p; total: ~p/~p"
+               , [Offsets, NMessages, Expected]
+               ),
+           ?assert(NMessages >= Expected)
+         end).
+
+wait_n_messages(TestGroupId, NMessages) ->
+  wait_n_messages(TestGroupId, NMessages, 30).
+
+-spec wait_for_port(string(), non_neg_integer()) -> ok.
+wait_for_port(Host, Port) ->
+  ?retry(1000, 10,
+         begin
+           {ok, Sock} = gen_tcp:connect(Host, Port, []),
+           gen_tcp:close(Sock),
+           ok
+         end).
+
+consumer_config() ->
+  %% Makes brod restart faster, this will hopefully shave off some
+  %% time from failure suites:
+  [ {max_wait_time, 500}
+  , {sleep_timeout, 100}
+  , {max_bytes, 1}
+  ].

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -6,6 +6,8 @@
         , produce/2
         , produce/3
         , produce/4
+        , payloads/1
+        , produce_payloads/3
         , create_topic/3
         , get_acked_offsets/1
         , check_committed_offsets/2
@@ -64,6 +66,17 @@ produce({Topic, Partition}, Key, Value, Headers) ->
                                              }]
                                          ),
   Offset.
+
+payloads(Config) ->
+  MaxSeqNo = proplists:get_value(max_seqno, Config, 10),
+  [<<I>> || I <- lists:seq(1, MaxSeqNo)].
+
+%% Produce binaries to the topic and return offset of the last message:
+produce_payloads(Topic, Partition, Config) ->
+  Payloads = payloads(Config),
+  ?log(notice, "Producing payloads to ~p", [{Topic, Partition}]),
+  LastOffset = lists:last([produce({Topic, Partition}, I) + 1 || I <- payloads(Config)]),
+  {LastOffset, Payloads}.
 
 client_config() ->
   case os:getenv("KAFKA_VERSION") of

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -94,7 +94,7 @@ create_topic(Name, NumPartitions, NumReplicas) ->
 exec_in_kafka_container(FMT, Args) ->
   CMD0 = lists:flatten(io_lib:format(FMT, Args)),
   CMD = "docker exec kafka-1 bash -c '" ++ CMD0 ++ "'",
-  Port = open_port({spawn, CMD}, [exit_status]),
+  Port = open_port({spawn, CMD}, [exit_status, stderr_to_stdout]),
   ?log(notice, "Running ~s~nin kafka container", [CMD0]),
   collect_port_output(Port, CMD).
 

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -58,7 +58,10 @@ produce({Topic, Partition}, Key, Value, Headers) ->
                                          , Topic
                                          , Partition
                                          , <<>>
-                                         , [#{value => Value, key => Key, headers => Headers}]
+                                         , [#{ value => Value
+                                             , key => Key
+                                             , headers => Headers
+                                             }]
                                          ),
   Offset.
 
@@ -94,7 +97,8 @@ exec_in_kafka_container(FMT, Args) ->
       error({timeout, FMT, Args})
   end.
 
--spec get_acked_offsets(brod:group_id()) -> #{brod:partition() => brod:offset()}.
+-spec get_acked_offsets(brod:group_id()) ->
+                           #{brod:partition() => brod:offset()}.
 get_acked_offsets(GroupId) ->
   {ok, [#{partition_responses := Resp}]} =
     brod:fetch_committed_offsets(?TEST_CLIENT_ID, GroupId),
@@ -112,7 +116,8 @@ check_committed_offsets(GroupId, Offsets) ->
                      %% rather than _last processed_. And this is
                      %% confusing.
                      ?assertEqual( Offset + 1
-                                 , maps:get(TopicPartition, CommittedOffsets, undefined)
+                                 , maps:get( TopicPartition, CommittedOffsets
+                                           , undefined)
                                  )
                  end
                , Offsets
@@ -126,7 +131,8 @@ wait_n_messages(TestGroupId, Expected, NRetries) ->
            Offsets = get_acked_offsets(TestGroupId),
            NMessages = lists:sum(maps:values(Offsets)),
            ?log( notice
-               , "Number of messages processed by consumer group: ~p; total: ~p/~p"
+               , "Number of messages processed by consumer group: ~p; "
+                 "total: ~p/~p"
                , [Offsets, NMessages, Expected]
                ),
            ?assert(NMessages >= Expected)


### PR DESCRIPTION
Splitting my other PR into manageable chunks. Since I am planning to change how group_subscriber spawn consumers, relying on mocking `brod:start_consumer` is no longer viable.

* Create topics dynamically
* Clean topics before running the tests
* Use a separate client for producing test data
* Start group_consumers from begin_offset=0 instead of latest offset
* Reduce the amount of copy-pasted code