### PR TITLE
allows to update_topics dynamically in a group

### DIFF
--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -51,6 +51,7 @@ create_topic "brod_consumer_SUITE"
 create_topic "brod_producer_SUITE"            2
 create_topic "brod_topic_subscriber_SUITE"    3 2
 create_topic "brod-group-coordinator"         3 2
+create_topic "brod-group-coordinator-1"       3 2
 create_topic "brod-group-subscriber-1"        3 2
 create_topic "brod-group-subscriber-2"        3 2
 create_topic "brod-group-subscriber-3"        3 2

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -289,9 +289,9 @@ commit_offsets(CoordinatorPid, Offsets0) ->
 
 %% @doc Update the list of topics the brod_group_coordinator follow which
 %% triggers a join group rebalance
--spec update_topics(pid(), [brod:topic()]) -> ok
+-spec update_topics(pid(), [brod:topic()]) -> ok.
 update_topics(CoordinatorPid, Topics) ->
-  gen_server:cast(CoordinatorPid,{update_topics, Topics}),
+  gen_server:cast(CoordinatorPid, {update_topics, Topics}),
   ok.
 
 %%%_* gen_server callbacks =====================================================
@@ -331,11 +331,6 @@ init({Client, GroupId, Topics, Config, CbModule, MemberPid}) ->
           , protocol_name                  = ProtocolName
           },
   {ok, State}.
-
-handle_cast({update_topics, Topics}, State) ->
-  NewState0 = State#state{ topics = Topics},
-  {ok, NewState1} = stabilize(NewState0, 0, topics),
-  {noreply, NewState1}.
 
 handle_info({ack, GenerationId, Topic, Partition, Offset}, State) ->
   {noreply, handle_ack(State, GenerationId, Topic, Partition, Offset)};
@@ -415,6 +410,10 @@ handle_call({commit_offsets, ExtraOffsets}, From, State) ->
 handle_call(Call, _From, State) ->
   {reply, {error, {unknown_call, Call}}, State}.
 
+handle_cast({update_topics, Topics}, State) ->
+  NewState0 = State#state{ topics = Topics},
+  {ok, NewState1} = stabilize(NewState0, 0, topics),
+  {noreply, NewState1};
 handle_cast(_Cast, #state{} = State) ->
   {noreply, State}.
 

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -291,8 +291,7 @@ commit_offsets(CoordinatorPid, Offsets0) ->
 %% triggers a join group rebalance
 -spec update_topics(pid(), [brod:topic()]) -> ok.
 update_topics(CoordinatorPid, Topics) ->
-  gen_server:cast(CoordinatorPid, {update_topics, Topics}),
-  ok.
+  gen_server:cast(CoordinatorPid, {update_topics, Topics}).
 
 %%%_* gen_server callbacks =====================================================
 
@@ -412,8 +411,8 @@ handle_call(Call, _From, State) ->
 
 handle_cast({update_topics, Topics}, State) ->
   NewState0 = State#state{ topics = Topics},
-  {ok, NewState1} = stabilize(NewState0, 0, topics),
-  {noreply, NewState1};
+  {ok, NewState} = stabilize(NewState0, 0, topics),
+  {noreply, NewState};
 handle_cast(_Cast, #state{} = State) ->
   {noreply, State}.
 

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -291,7 +291,7 @@ commit_offsets(CoordinatorPid, Offsets0) ->
 %% triggers a join group rebalance
 -spec update_topics(pid(), [brod:topic()]) -> ok
 update_topics(CoordinatorPid, Topics) ->
-  CoordinatorPid ! {topics, Topics},
+  gen_server:cast(CoordinatorPid,{update_topics, Topics}),
   ok.
 
 %%%_* gen_server callbacks =====================================================
@@ -332,10 +332,11 @@ init({Client, GroupId, Topics, Config, CbModule, MemberPid}) ->
           },
   {ok, State}.
 
-handle_info({topics, Topics}, State) ->
+handle_cast({update_topics, Topics}, State) ->
   NewState0 = State#state{ topics = Topics},
   {ok, NewState1} = stabilize(NewState0, 0, topics),
   {noreply, NewState1}.
+
 handle_info({ack, GenerationId, Topic, Partition, Offset}, State) ->
   {noreply, handle_ack(State, GenerationId, Topic, Partition, Offset)};
 handle_info(?LO_CMD_COMMIT_OFFSETS, #state{is_in_group = true} = State) ->

--- a/test/brod_group_coordinator_SUITE.erl
+++ b/test/brod_group_coordinator_SUITE.erl
@@ -19,6 +19,7 @@
 -define(CLIENT_ID, ?MODULE).
 -define(OTHER_CLIENT_ID, other_coordinator_id).
 -define(TOPIC, <<"brod-group-coordinator">>).
+-define(TOPIC1, <<"brod-group-coordinator-1">>).
 -define(GROUP, <<"brod-group-coordinator">>).
 -define(PARTITION, 0).
 
@@ -36,7 +37,9 @@
         ]).
 
 %% Test cases
--export([ t_acks_during_revoke/1 ]).
+-export([ t_acks_during_revoke/1
+        , t_update_topics_triggers_rebalance/1
+        ]).
 
 -define(assert_receive(Pattern, Return),
   receive
@@ -130,6 +133,20 @@ t_acks_during_revoke(Config) when is_list(Config) ->
               ),
 
   ok.
+
+t_update_topics_triggers_rebalance(Config) when is_list(Config) ->
+    {ok, GroupCoordinatorPid} =
+    brod_group_coordinator:start_link(?CLIENT_ID, ?GROUP, [?TOPIC],
+                                      _Config = [], ?MODULE, {self(), 1}),
+  ?assert_receive({assignments_revoked, 1}, ok),
+  GroupCoordinatorPid ! continue,
+  GenerationId1 = ?assert_receive({assignments_received, 1, GId1, _}, GId1),
+
+  brod_group_coordinator:update_topics(GroupCoordinatorPid, [?TOPIC1]),
+  ?assert_receive({assignments_revoked, 1}, ok),
+  GroupCoordinatorPid ! continue,
+  GenerationId2 = ?assert_receive({assignments_received, 1, GId2, _}, GId2),
+  ?assert(GenerationId2 > GenerationId1).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:


### PR DESCRIPTION
This introduce a new public API function, that update the topic then trigger a stabilize.

This allows to dynamically change the topics in a consumer group coordinator.

There is no test for this presently, i am not sure of what would make sense to test here. If you want some tests, let's discuss it.