### PR TITLE
Update test to please DRY rule check in elvis

### DIFF
--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -1140,13 +1140,13 @@ is_default_offset_retention(_) -> false.
 merge_acked_offsets_test() ->
   ?assertEqual([{{<<"topic1">>, 1}, 1}],
                merge_acked_offsets([], [{{<<"topic1">>, 1}, 1}])),
-  ?assertEqual([{{<<"topic1">>, 1}, 1}, {{<<"topic1">>, 2}, 1}],
-               merge_acked_offsets([{{<<"topic1">>, 1}, 1}],
-                                   [{{<<"topic1">>, 2}, 1}])),
-  ?assertEqual([{{<<"topic1">>, 1}, 2}, {{<<"topic1">>, 2}, 1}],
-               merge_acked_offsets([{{<<"topic1">>, 1}, 1},
-                                    {{<<"topic1">>, 2}, 1}],
-                                   [{{<<"topic1">>, 1}, 2}])),
+  ?assertEqual([{{<<"topic2">>, 1}, 1}, {{<<"topic2">>, 2}, 1}],
+               merge_acked_offsets([{{<<"topic2">>, 1}, 1}],
+                                   [{{<<"topic2">>, 2}, 1}])),
+  ?assertEqual([{{<<"topic3">>, 1}, 2}, {{<<"topic3">>, 2}, 1}],
+               merge_acked_offsets([{{<<"topic3">>, 1}, 1},
+                                    {{<<"topic3">>, 2}, 1}],
+                                   [{{<<"topic3">>, 1}, 2}])),
   ok.
 
 is_roundrobin_v1_commit_test() ->


### PR DESCRIPTION
This corrects an issue found during the Travis build.

When Travis is running it uses the latest version of rebar3 and elvis,
but the latest elvis has a change regarding how it handles macros.
Elvis depends on katana_code, which has replaced the pre-processor handling, see:
https://github.com/inaka/katana-code/pull/31

This has changed the behavior of elvis to also include code defined in TEST scope in its checks,
which this PR simply fixes.
This could also be solved by pinning elvis to a specific older version..