### PR TITLE
Corrections to get build checks passed

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -2,7 +2,7 @@ IsRebar3 = erlang:function_exported(rebar3, main, 1),
 DocoptUrl = "https://github.com/zmstone/docopt-erl.git",
 DocOptTag = "0.1.3",
 DocoptDep = {docopt, {git, DocoptUrl, {branch, DocOptTag}}},
-Snabbkaffe = {snabbkaffe, {git, "https://github.com/klarna/snabbkaffe.git", {branch, "master"}}}, % TODO: use release tag
+Snabbkaffe = {snabbkaffe, "0.3.3"},
 Profiles =
   {profiles, [
     {brod_cli, [

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -1140,13 +1140,13 @@ is_default_offset_retention(_) -> false.
 merge_acked_offsets_test() ->
   ?assertEqual([{{<<"topic1">>, 1}, 1}],
                merge_acked_offsets([], [{{<<"topic1">>, 1}, 1}])),
-  ?assertEqual([{{<<"topic1">>, 1}, 1}, {{<<"topic1">>, 2}, 1}],
-               merge_acked_offsets([{{<<"topic1">>, 1}, 1}],
-                                   [{{<<"topic1">>, 2}, 1}])),
-  ?assertEqual([{{<<"topic1">>, 1}, 2}, {{<<"topic1">>, 2}, 1}],
-               merge_acked_offsets([{{<<"topic1">>, 1}, 1},
-                                    {{<<"topic1">>, 2}, 1}],
-                                   [{{<<"topic1">>, 1}, 2}])),
+  ?assertEqual([{{<<"topic2">>, 1}, 1}, {{<<"topic2">>, 2}, 1}],
+               merge_acked_offsets([{{<<"topic2">>, 1}, 1}],
+                                   [{{<<"topic2">>, 2}, 1}])),
+  ?assertEqual([{{<<"topic3">>, 1}, 2}, {{<<"topic3">>, 2}, 1}],
+               merge_acked_offsets([{{<<"topic3">>, 1}, 1},
+                                    {{<<"topic3">>, 2}, 1}],
+                                   [{{<<"topic3">>, 1}, 2}])),
   ok.
 
 is_roundrobin_v1_commit_test() ->


### PR DESCRIPTION
### Pin version of test dependency snabbkaffe
This avoids breakage due to test framework development,
and will enable the common test suites again.

### Update test to please DRY rule check in elvis 
This corrects an issue found during the Travis build, from #385

When Travis is running it uses the latest version of rebar3 and elvis,
but the latest elvis has a change regarding how it handles macros.
Elvis depends on katana_code, which has replaced the pre-processor handling, see:
inaka/katana-code#31

This has changed the behavior of elvis to also include code defined in TEST scope in its checks,
which this PR simply fixes.
This could also be solved by pinning elvis to a specific older version..