### PR TITLE
Make brod a compatible client with Microsoft's EventHub.

### DIFF
--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -620,6 +620,9 @@ kill_fetcher({Pid, Mref}) ->
       ok
   end.
 
+drop_aborted(#{aborted_transactions := undefined}, Batches) ->
+  %% Microsoft's EventHub sends nil value instead of an empty list for this key.
+  Batches;
 drop_aborted(#{aborted_transactions := AbortedL}, Batches) ->
   %% Drop batches for each abored transaction
   lists:foldl(


### PR DESCRIPTION
The field "aborted_transaction" seems to contain nil instead of an empty list in the message from MS's EventHub which causes an error in the drop_aborted function.

I don't know if there is any intention of keeping compatibility with EventHub or if this is the most appropriate fix. Let me know if there is anything else I can do.