### PR TITLE
Fix brod-cli release nif copy

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -13,7 +13,7 @@ Profiles =
                [brod, jsone, docopt]},
               {include_erts, true},
               {overlay, [{copy, "scripts/brod", "bin"},
-                         {copy, "{{lib_dirs}}/crc32cer/priv/crc32cer.so", "bin"},
+                         {copy, "{{lib_dirs}}/crc32cer/priv/crc32cer*.so", "bin"},
                          {copy, "{{lib_dirs}}/snappyer/priv/snappyer.so", "bin"}
                         ]}
              ]}]},


### PR DESCRIPTION
crc32cer so file renamed since it changed from makefile to
port_compiler

the so file is now named  `crc32cer_nif.so`