### PR TITLE
fix aborted transactions

### DIFF
--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -620,6 +620,8 @@ kill_fetcher({Pid, Mref}) ->
       ok
   end.
 
+drop_aborted(#{aborted_transactions := undefined} = Map, Batches) ->
+  drop_aborted(maps:put(aborted_transactions, [], Map), Batches);
 drop_aborted(#{aborted_transactions := AbortedL}, Batches) ->
   %% Drop batches for each abored transaction
   lists:foldl(


### PR DESCRIPTION
We use Azure event hub and we get :undefined for aborted_transactions, this could help us