### PR TITLE
brod_cli_tests:cmd/1: ensure brod_kafka_apis is gone before returning

### DIFF
--- a/test/brod_cli_tests.erl
+++ b/test/brod_cli_tests.erl
@@ -193,7 +193,20 @@ cmd(Args) ->
     catch brod:stop_client(brod_cli_client),
     Result
   after
-    _ = brod:stop()
+    _ = brod:stop(),
+    ensure_down(brod_kafka_apis)
+  end.
+
+ensure_down(RegName) -> ensure_down(RegName, 10).
+
+ensure_down(RegName, 0) -> error({wont_die, RegName});
+ensure_down(RegName, N) ->
+  case whereis(RegName) of
+    undefined -> ok;
+    Pid ->
+      exit(Pid, kill),
+      timer:sleep((11 - N) * 10),
+      ensure_down(RegName, N - 1)
   end.
 
 io_loop(Parent, Acc0) ->


### PR DESCRIPTION
A pending PR has a build error with OTP-19, caused by what looks like a race between shutting down the brod application and its linked processes for one test, and starting it for another: the start failed because brod_kafka_apis hadn't terminated yet.

This adds code to brod_cli_tests:cmd/1 to also ensure that brod_kafka_apis is gone before returning, if necessary by killing it and looping briefly.

See: https://travis-ci.org/github/klarna/brod/jobs/692218660