### PR TITLE
Group subscriber v2 terminate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+* 3.14.0
+  * Introduced a new optional terminate/1 callback to
+    brod_topic_subscriber and brod_group_subscriber_v2 behaviors
+
+  * Introduced new API functions for starting topic subscribers:
+    brod_topic_subscriber:start_link/1 and brod:start_link_topic_subscriber/1
+    Old APIs
+      * brod:start_link_topic_subscriber/5,
+      * brod:start_link_topic_subscriber/6
+      * brod:start_link_topic_subscriber/7
+      * brod_topic_subscriber:start_link/6
+      * brod_topic_subscriber:start_link/7
+      * brod_topic_subscriber:start_link/8
+    are deprecated and will be removed in the next major release
 * 3.13.0
   * Update supervisor3 dependency to 1.1.11
   * brod_group_subscriber_v2 behavior handles worker crashes

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 * 3.14.0
-  * Introduced a new optional terminate/1 callback to
+  NOTE: This release changes internal states of brod worker processes
+  in a way that cannot by applied on a running system. brod application
+  and all brod workers should be shot down for the time of the upgrade.
+
+  * Introduced a new optional terminate/2 callback to
     brod_topic_subscriber and brod_group_subscriber_v2 behaviors
 
   * Introduced new API functions for starting topic subscribers:

--- a/elvis.config
+++ b/elvis.config
@@ -5,7 +5,7 @@
                   ],
           filter => "*.erl",
           rules => [ {elvis_style, line_length,
-                      #{ limit => 80,
+                      #{ limit => 100,
                          skip_comments => false
                        }}
                    , {elvis_style, no_tabs}
@@ -67,7 +67,7 @@
         #{ dirs => ["test"]
          , filter => "*.erl"
          , rules => [ {elvis_style, line_length,
-                       #{ limit => 80
+                       #{ limit => 100
                         , skip_comments => false
                         }}
                     ]

--- a/include/brod_int.hrl
+++ b/include/brod_int.hrl
@@ -35,6 +35,12 @@
                 , node_id :: integer()
                 }).
 
+-record(cbm_init_data,
+        { committed_offsets :: brod_topic_subscriber:committed_offsets()
+        , cb_fun            :: brod_topic_subscriber:cb_fun()
+        , cb_data           :: term()
+        }).
+
 -type sasl_opt() :: {plain, User :: string() | binary(),
                             Pass :: string() | binary() |
                                     fun(() -> string() | binary())}

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
        , {kafka_protocol, "2.3.6"}
        ]}.
 {edoc_opts, [{preprocess, true}, {macros, [{build_brod_cli, true}]}]}.
-{erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,warn_obsolete_guard,debug_info]}.
+{erl_opts, [warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, deprecated_function_calls,
                deprecated_functions]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -2,7 +2,7 @@ IsRebar3 = erlang:function_exported(rebar3, main, 1),
 DocoptUrl = "https://github.com/zmstone/docopt-erl.git",
 DocOptTag = "0.1.3",
 DocoptDep = {docopt, {git, DocoptUrl, {branch, DocOptTag}}},
-Snabbkaffe = {snabbkaffe, {git, "https://github.com/klarna/snabbkaffe", {tag, "0.5.0"}}},
+Snabbkaffe = {snabbkaffe, {git, "https://github.com/klarna/snabbkaffe", {tag, "0.6.0"}}},
 Profiles =
   {profiles, [
     {brod_cli, [

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -70,9 +70,13 @@
         ]).
 
 %% Subscriber API
+-export([ start_link_group_subscriber_v2/1
+        , start_link_topic_subscriber/1
+        ]).
+
+%% Deprecated API
 -export([ start_link_group_subscriber/7
         , start_link_group_subscriber/8
-        , start_link_group_subscriber_v2/1
         , start_link_topic_subscriber/5
         , start_link_topic_subscriber/6
         , start_link_topic_subscriber/7
@@ -749,6 +753,7 @@ start_link_group_subscriber(Client, GroupId, Topics, GroupConfig,
 
 %% @equiv start_link_topic_subscriber(Client, Topic, 'all', ConsumerConfig,
 %%                                    CbModule, CbInitArg)
+%% @deprecated Please use {@link start_link_topic_subscriber/1} instead
 -spec start_link_topic_subscriber(
         client(), topic(), consumer_config(), module(), term()) ->
           {ok, pid()} | {error, any()}.
@@ -760,6 +765,7 @@ start_link_topic_subscriber(Client, Topic, ConsumerConfig,
 %% @equiv start_link_topic_subscriber(Client, Topic, Partitions,
 %%                                    ConsumerConfig, message,
 %%                                    CbModule, CbInitArg)
+%% @deprecated Please use {@link start_link_topic_subscriber/1} instead
 -spec start_link_topic_subscriber(
         client(), topic(), all | [partition()],
         consumer_config(), module(), term()) ->
@@ -770,6 +776,7 @@ start_link_topic_subscriber(Client, Topic, Partitions,
                               ConsumerConfig, message, CbModule, CbInitArg).
 
 %% @see brod_topic_subscriber:start_link/7
+%% @deprecated Please use {@link start_link_topic_subscriber/1} instead
 -spec start_link_topic_subscriber(
         client(), topic(), all | [partition()],
         consumer_config(), message | message_set,
@@ -780,6 +787,12 @@ start_link_topic_subscriber(Client, Topic, Partitions,
   brod_topic_subscriber:start_link(Client, Topic, Partitions,
                                    ConsumerConfig, MessageType,
                                    CbModule, CbInitArg).
+
+%% @see brod_topic_subscriber:start_link/1
+-spec start_link_topic_subscriber(brod_topic_subscriber:topic_subscriber_config()) ->
+          {ok, pid()} | {error, any()}.
+start_link_topic_subscriber(Config) ->
+  brod_topic_subscriber:start_link(Config).
 
 %% @equiv create_topics(Hosts, TopicsConfigs, RequestConfigs, [])
 -spec create_topics([endpoint()], [topic_config()], #{timeout => kpro:int32(),

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -789,8 +789,9 @@ start_link_topic_subscriber(Client, Topic, Partitions,
                                    CbModule, CbInitArg).
 
 %% @see brod_topic_subscriber:start_link/1
--spec start_link_topic_subscriber(brod_topic_subscriber:topic_subscriber_config()) ->
-          {ok, pid()} | {error, any()}.
+-spec start_link_topic_subscriber(
+        brod_topic_subscriber:topic_subscriber_config()
+       ) -> {ok, pid()} | {error, any()}.
 start_link_topic_subscriber(Config) ->
   brod_topic_subscriber:start_link(Config).
 

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -1079,10 +1079,7 @@ make_offset_commit_metadata() ->
 %% should be set in the assign_partitions callback implemenation.
 user_data(Module, Pid) ->
   %% Module is ensured to be loaded already
-  case erlang:function_exported(Module, user_data, 1) of
-    true -> Module:user_data(Pid);
-    false -> <<>>
-  end.
+  brod_utils:optional_callback(Module, user_data, [Pid], <<>>).
 
 %% Make a client ID to be used in the requests sent over the group
 %% coordinator's connection (group coordinator broker on the other end),

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -98,7 +98,7 @@
 
 -callback terminate(_Reason, _State) -> _.
 
--optional_callbacks([assign_partitions/3, get_committed_offset/3, terminate/1]).
+-optional_callbacks([assign_partitions/3, get_committed_offset/3, terminate/2]).
 
 -define(DOWN(Reason), {down, brod_utils:os_time_utc_str(), Reason}).
 

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -96,7 +96,7 @@
                             [brod:topic_partition()]) ->
   [{member_id(), [brod:partition_assignment()]}].
 
--callback terminate(_State) -> _.
+-callback terminate(_Reason, _State) -> _.
 
 -optional_callbacks([assign_partitions/3, get_committed_offset/3, terminate/1]).
 

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -96,7 +96,9 @@
                             [brod:topic_partition()]) ->
   [{member_id(), [brod:partition_assignment()]}].
 
--optional_callbacks([assign_partitions/3, get_committed_offset/3]).
+-callback terminate(_State) -> _.
+
+-optional_callbacks([assign_partitions/3, get_committed_offset/3, terminate/1]).
 
 -define(DOWN(Reason), {down, brod_utils:os_time_utc_str(), Reason}).
 

--- a/src/brod_group_subscriber_worker.erl
+++ b/src/brod_group_subscriber_worker.erl
@@ -21,8 +21,8 @@
 
 -include("brod_int.hrl").
 
-%% Brod callbacks
--export([init/2, handle_message/3]).
+%% brod_topic_subscriber callbacks
+-export([init/2, handle_message/3, terminate/1]).
 
 -type start_options() ::
         #{ group_id     := brod:group_id()
@@ -97,6 +97,9 @@ handle_message(_Partition, Msg, State) ->
       NewState = State#state{cb_state = NewCbState},
       {ok, NewState}
   end.
+
+terminate(#state{cb_module = CbModule, cb_state = State}) ->
+  brod_utils:optional_callback(CbModule, terminate, [State], ok).
 
 %%%===================================================================
 %%% Internal functions

--- a/src/brod_group_subscriber_worker.erl
+++ b/src/brod_group_subscriber_worker.erl
@@ -22,7 +22,7 @@
 -include("brod_int.hrl").
 
 %% brod_topic_subscriber callbacks
--export([init/2, handle_message/3, terminate/1]).
+-export([init/2, handle_message/3, terminate/2]).
 
 -type start_options() ::
         #{ group_id     := brod:group_id()
@@ -98,8 +98,8 @@ handle_message(_Partition, Msg, State) ->
       {ok, NewState}
   end.
 
-terminate(#state{cb_module = CbModule, cb_state = State}) ->
-  brod_utils:optional_callback(CbModule, terminate, [State], ok).
+terminate(Reason, #state{cb_module = CbModule, cb_state = State}) ->
+  brod_utils:optional_callback(CbModule, terminate, [Reason, State], ok).
 
 %%%===================================================================
 %%% Internal functions

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -285,8 +285,15 @@ init(_Topic, #cbm_init_data{ committed_offsets = CommittedOffsets
                            }) ->
   {ok, CommittedOffsets, {CbFun, CbState}}.
 
-handle_message(Partition, Msg, {CbFun, CbState}) ->
-  {CbFun, CbFun(Partition, Msg, CbState)}.
+handle_message(Partition, Msg, {CbFun, CbState0}) ->
+  case CbFun(Partition, Msg, CbState0) of
+    {ok, ack, CbState} ->
+      {ok, ack, {CbFun, CbState}};
+    {ok, CbState} ->
+      {ok, {CbFun, CbState}};
+    Err ->
+      Err
+  end.
 
 %%%_* gen_server callbacks =====================================================
 

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -103,6 +103,11 @@
                          brod:message() | brod:message_set(),
                          cb_state()) -> cb_ret().
 
+%% This callback is called before stopping the subscriber
+-callback terminate(cb_state()) -> _.
+
+-optional_callbacks([terminate/1]).
+
 %%%_* Types and macros =========================================================
 
 -record(consumer,
@@ -352,6 +357,10 @@ handle_cast({ack, Partition, Offset}, State) ->
   NewState = handle_ack(AckRef, State),
   {noreply, NewState};
 handle_cast(stop, State) ->
+  #state{ cb_state = CbState
+        , cb_module = CbModule
+        } = State,
+  brod_utils:optional_callback(CbModule, terminate, [CbState], ok),
   {stop, normal, State};
 handle_cast(_Cast, State) ->
   {noreply, State}.

--- a/src/brod_topic_subscriber_cb_fun.erl
+++ b/src/brod_topic_subscriber_cb_fun.erl
@@ -1,0 +1,47 @@
+%%%
+%%%   Copyright (c) 2020 Klarna Bank AB (publ)
+%%%
+%%%   Licensed under the Apache License, Version 2.0 (the "License");
+%%%   you may not use this file except in compliance with the License.
+%%%   You may obtain a copy of the License at
+%%%
+%%%       http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%%   Unless required by applicable law or agreed to in writing, software
+%%%   distributed under the License is distributed on an "AS IS" BASIS,
+%%%   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%%   See the License for the specific language governing permissions and
+%%%   limitations under the License.
+%%%
+
+%%%=============================================================================
+%%% @private
+%%% A wrapper module that enables backward compatible use of
+%%% `brod_topic_subscriber' with a fun instead of a callback module.
+%%% @end
+%%%=============================================================================
+-module(brod_topic_subscriber_cb_fun).
+
+-behavior(brod_topic_subscriber).
+
+-export([init/2, handle_message/3]).
+
+-include("brod_int.hrl").
+
+%% @private This is needed to implement backward-consistent `cb_fun'
+%% interface.
+init(_Topic, #cbm_init_data{ committed_offsets = CommittedOffsets
+                           , cb_fun            = CbFun
+                           , cb_data           = CbState
+                           }) ->
+  {ok, CommittedOffsets, {CbFun, CbState}}.
+
+handle_message(Partition, Msg, {CbFun, CbState0}) ->
+  case CbFun(Partition, Msg, CbState0) of
+    {ok, ack, CbState} ->
+      {ok, ack, {CbFun, CbState}};
+    {ok, CbState} ->
+      {ok, {CbFun, CbState}};
+    Err ->
+      Err
+  end.

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -51,6 +51,7 @@
         , make_fetch_fun/4
         , make_part_fun/1
         , os_time_utc_str/0
+        , optional_callback/4
         , parse_rsp/1
         , request_sync/2
         , request_sync/3
@@ -192,6 +193,17 @@ os_time_utc_str() ->
   S = io_lib:format("~4.4.0w-~2.2.0w-~2.2.0w:~2.2.0w:~2.2.0w:~2.2.0w.~6.6.0w",
                     [Y, M, D, H, Min, Sec, Micro]),
   lists:flatten(S).
+
+%% @doc Execute a callback from a module, if present.
+-spec optional_callback(module(), atom(), list(), Ret) -> Ret.
+optional_callback(Module, Function, Args, Default) ->
+  Arity = length(Args),
+  case erlang:function_exported(Module, Function, Arity) of
+    true ->
+      apply(Module, Function, Args);
+    false ->
+      Default
+  end.
 
 %% @doc Milliseconds since beginning of the epoch (midnight Jan 1, 1970 (UTC)).
 -spec epoch_ms() -> kpro:msg_ts().

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -471,7 +471,15 @@ t_async_commit(Config) when is_list(Config) ->
          %% had been committed:
          ?assertMatch( []
                      , ?projection(value, handled_messages(AfterRestart2))
-                     )
+                     ),
+         %% Check that terminate callback was called on each restart
+         %% (for the new behavior):
+         Behavior =:= brod_group_subscriber orelse
+           ?assertMatch( [ #{topic := Topic, partition := Partition}
+                         , #{topic := Topic, partition := Partition}
+                         ]
+                       , ?of_kind(brod_test_group_subscriber_terminate, Trace)
+                       )
      end).
 
 t_assign_partitions_handles_updating_state(Config) when is_list(Config) ->

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -299,7 +299,7 @@ t_consumer_crash(Config) when is_list(Config) ->
        ok = Behavior:ack(SubscriberPid, Topic, Partition, O3),
        sys:get_state(SubscriberPid),
        {ok, ConsumerPid} = brod:get_consumer(?CLIENT_ID, Topic, Partition),
-       kill_process(ConsumerPid),
+       kafka_test_helper:kill_process(ConsumerPid),
        %% send more messages (but they should not be received until
        %% re-subscribe)
        [SendFun(I) || I <- lists:seq(6, 8)],
@@ -570,17 +570,6 @@ start_subscriber(Config, Topics, GroupConfig, ConsumerConfig, InitArgs) ->
 
 stop_subscriber(Config, Pid) ->
   (?config(behavior)):stop(Pid).
-
-kill_process(Pid) ->
-  Mon = monitor(process, Pid),
-  ?tp(kill_consumer, #{pid => Pid}),
-  exit(Pid, kill),
-  receive
-    {'DOWN', Mon, process, Pid, killed} ->
-      ok
-  after 1000 ->
-      ct:fail("timed out waiting for the process to die")
-  end.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/brod_test_group_subscriber.erl
+++ b/test/brod_test_group_subscriber.erl
@@ -27,7 +27,7 @@
         , get_committed_offset/3
         , handle_message/2
         , assign_partitions/3
-        , terminate/1
+        , terminate/2
         ]).
 
 init(InitInfo, Config) ->
@@ -76,10 +76,11 @@ assign_partitions(_CbConfig, Members, TopicPartitions) ->
                            || {Topic, PartitionsN} <- TopicPartitions],
   [{element(1, hd(Members)), PartitionsAssignments}].
 
-terminate(#state{ topic = Topic
-                , partition = Partition
-                }) ->
+terminate(Reason, #state{ topic = Topic
+                        , partition = Partition
+                        }) ->
   ?tp(brod_test_group_subscriber_terminate,
-      #{ topic => Topic
+      #{ topic     => Topic
        , partition => Partition
+       , readon    => Reason
        }).

--- a/test/brod_test_group_subscriber.erl
+++ b/test/brod_test_group_subscriber.erl
@@ -27,6 +27,7 @@
         , get_committed_offset/3
         , handle_message/2
         , assign_partitions/3
+        , terminate/1
         ]).
 
 init(InitInfo, Config) ->
@@ -74,3 +75,11 @@ assign_partitions(_CbConfig, Members, TopicPartitions) ->
   PartitionsAssignments = [{Topic, [PartitionsN]}
                            || {Topic, PartitionsN} <- TopicPartitions],
   [{element(1, hd(Members)), PartitionsAssignments}].
+
+terminate(#state{ topic = Topic
+                , partition = Partition
+                }) ->
+  ?tp(brod_test_group_subscriber_terminate,
+      #{ topic => Topic
+       , partition => Partition
+       }).

--- a/test/brod_topic_subscriber_SUITE.erl
+++ b/test/brod_topic_subscriber_SUITE.erl
@@ -37,6 +37,7 @@
         , t_demo_message_set/1
         , t_consumer_crash/1
         , t_begin_offset/1
+        , t_cb_fun/1
         ]).
 
 -include("brod_test_setup.hrl").
@@ -66,29 +67,39 @@ common_end_per_testcase(Case, Config) ->
 
 %%%_* Topic subscriber callbacks ===============================================
 
--record(state, { ct_case_ref
-               , ct_case_pid
-               , is_async_ack
-               }).
+-record(state,
+        { is_async_ack :: boolean()
+        , counter      :: integer()
+        , worker_id    :: reference()
+        }).
 
-init(Topic, {CaseRef, CasePid, IsAsyncAck}) ->
-  init(Topic, {CaseRef, CasePid, IsAsyncAck, _CommittedOffsets = []});
-init(_Topic, {CaseRef, CasePid, IsAsyncAck, CommittedOffsets}) ->
-  State = #state{ ct_case_ref  = CaseRef
-                , ct_case_pid  = CasePid
-                , is_async_ack = IsAsyncAck
+init(_Topic, {IsAsyncAck, CommittedOffsets}) ->
+  Ref = make_ref(),
+  ?tp(topic_subscriber_init,
+      #{ worker_id => Ref
+       , state     => 0
+       }),
+  State = #state{ is_async_ack = IsAsyncAck
+                , counter      = 1
+                , worker_id    = Ref
                 },
   {ok, CommittedOffsets, State}.
 
-handle_message(Partition, Message, #state{ ct_case_ref  = Ref
-                                         , ct_case_pid  = Pid
-                                         , is_async_ack = IsAsyncAck
-                                         } = State) ->
+handle_message(Partition, Message, #state{ is_async_ack = IsAsyncAck
+                                         , counter      = Counter
+                                         , worker_id    = Ref
+                                         } = State0) ->
   #kafka_message{ offset = Offset
                 , value  = Value
                 } = Message,
-  %% forward the message to ct case for verification.
-  Pid ! {Ref, Partition, Offset, Value},
+  ?tp(topic_subscriber_seen_message,
+     #{ partition => Partition
+      , offset    => Offset
+      , value     => Value
+      , state     => Counter
+      , worker_id => Ref
+      }),
+  State = State0#state{counter = Counter + 1},
   case IsAsyncAck of
     true  -> {ok, State};
     false -> {ok, ack, State}
@@ -141,45 +152,35 @@ t_async_acks(Config) when is_list(Config) ->
                    , {sleep_timeout, 0}
                    , {max_wait_time, 1000}
                    ],
-  CaseRef = t_async_acks,
-  CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true},
-  Partition = 0,
-  {ok, SubscriberPid} =
-    brod:start_link_topic_subscriber(?CLIENT_ID, ?topic, ConsumerConfig,
-                                     ?MODULE, InitArgs),
-  SendFun =
-    fun(I) ->
-      Value = integer_to_binary(I),
-      produce({?topic, Partition}, Value)
-    end,
-  RecvFun =
-    fun F(Timeout, Acc) ->
-      receive
-        {CaseRef, Partition, Offset, Value} ->
-          ok = brod_topic_subscriber:ack(SubscriberPid, Partition, Offset),
-          I = binary_to_integer(Value),
-          F(0, [I | Acc]);
-        Msg ->
-          erlang:error({unexpected_msg, Msg})
-      after Timeout ->
-        Acc
-      end
-    end,
-  SendFun(0),
-  %% wait at most 2 seconds to receive the first message
-  %% it may or may not receive the first message (0) depending on when
-  %% the consumers starts polling --- before or after the first message
-  %% is produced.
-  _ = RecvFun(2000, []),
-  L = lists:seq(1, MaxSeqNo),
-  ok = lists:foreach(SendFun, L),
-  %% worst case scenario, the receive loop will cost (100 * 5 + 5 * 1000) ms
-  Timeouts = lists:duplicate(MaxSeqNo, 5) ++ lists:duplicate(5, 1000),
-  ReceivedL = lists:foldl(RecvFun, [], Timeouts ++ [1,2,3,4,5]),
-  ?assertEqual(L, lists:reverse(ReceivedL)),
-  ok = brod_topic_subscriber:stop(SubscriberPid),
-  ok.
+  InitArgs = {_IsAsyncAck = true, _CommittedOffsets = []},
+  ?check_trace(
+     %% Run stage:
+     begin
+      {ok, SubscriberPid} =
+         brod:start_link_topic_subscriber(?CLIENT_ID, ?topic, ConsumerConfig,
+                                          ?MODULE, InitArgs),
+       produce({?topic, 0}, <<0>>),
+       %% wait at most 2 seconds to receive the first message
+       %% it may or may not receive the first message (0) depending on when
+       %% the consumers starts polling --- before or after the first message
+       %% is produced:
+       _ = wait_message(<<0>>, 2000),
+       %% Send messages:
+       Messages = [<<I>> || I <- lists:seq(1, MaxSeqNo)],
+       [produce({?topic, 0}, I) || I <- Messages],
+       %% Ack messages:
+       wait_and_ack(SubscriberPid, Messages),
+       ok = brod_topic_subscriber:stop(SubscriberPid),
+       Messages
+     end,
+     %% Check stage:
+     fun(Expected, Trace) ->
+         Received = ?projection(value, ?of_kind( topic_subscriber_seen_message
+                                               , Trace
+                                               )) -- [<<0>>],
+         %% Check that all messages have been received once:
+         ?assertEqual(Expected, Received)
+     end).
 
 t_begin_offset(Config) when is_list(Config) ->
   ConsumerConfig = [ {prefetch_count, 100}
@@ -187,39 +188,32 @@ t_begin_offset(Config) when is_list(Config) ->
                    , {sleep_timeout, 0}
                    , {max_wait_time, 1000}
                    ],
-  CaseRef = t_begin_offset,
-  CasePid = self(),
-  Partition = 0,
   SendFun =
     fun(I) ->
-      Value = integer_to_binary(I),
-      produce({?topic, Partition}, Value)
+      produce({?topic, 0}, <<I>>)
     end,
-  RecvFun =
-    fun F(Pid, Timeout, Acc) ->
-      receive
-        {CaseRef, Partition, Offset, Value} ->
-          ok = brod_topic_subscriber:ack(Pid, Partition, Offset),
-          I = binary_to_integer(Value),
-          F(Pid, 0, [{Offset, I} | Acc]);
-        Msg ->
-          erlang:error({unexpected_msg, Msg})
-      after Timeout ->
-        Acc
-      end
-    end,
-  _Offset0 = SendFun(111),
-  Offset1 = SendFun(222),
-  Offset2 = SendFun(333),
-  %% Start as if committed Offset1, expect it to start fetching from Offset2
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true,
-              _ConsumerOffsets = [{0, Offset1}]},
-  {ok, SubscriberPid} =
-    brod:start_link_topic_subscriber(?CLIENT_ID, ?topic, ConsumerConfig,
-                                     ?MODULE, InitArgs),
-  ?assertEqual([{Offset2, 333}], RecvFun(SubscriberPid, 5000, [])),
-  ok = brod_topic_subscriber:stop(SubscriberPid),
-  ok.
+  ?check_trace(
+     %% Run stage:
+     begin
+       _Offset0 = SendFun(1),
+       Offset1 = SendFun(2),
+       Offset2 = SendFun(3),
+       %% Start as if committed Offset1, expect it to start fetching from Offset2
+       InitArgs = {_IsAsyncAck = true,
+                   _ConsumerOffsets = [{0, Offset1}]},
+       {ok, SubscriberPid} =
+         brod:start_link_topic_subscriber(?CLIENT_ID, ?topic, ConsumerConfig,
+                                          ?MODULE, InitArgs),
+       Expected = [<<3>>],
+       wait_and_ack(SubscriberPid, Expected),
+       ok = brod_topic_subscriber:stop(SubscriberPid),
+       Expected
+     end,
+     %% Check stage:
+     fun(Expected, Trace) ->
+         check_received_messages(Expected, Trace),
+         check_state_continuity(Trace)
+     end).
 
 t_consumer_crash(Config) when is_list(Config) ->
   ConsumerConfig = [ {prefetch_count, 10}
@@ -227,60 +221,131 @@ t_consumer_crash(Config) when is_list(Config) ->
                    , {max_wait_time, 1000}
                    , {partition_restart_delay_seconds, 1}
                    ],
-  CaseRef = t_consumer_crash,
-  CasePid = self(),
-  InitArgs = {CaseRef, CasePid, _IsAsyncAck = true},
+  InitArgs = {_IsAsyncAck = true, _CommittedOffsets = []},
   Partition = 0,
-  {ok, SubscriberPid} =
-    brod:start_link_topic_subscriber(?CLIENT_ID, ?topic, ConsumerConfig,
-                                     ?MODULE, InitArgs),
   SendFun =
     fun(I) ->
         produce({?topic, Partition}, <<I>>)
     end,
-  ReceiveFun =
-    fun F(MaxI, Acc) ->
-        receive
-          {CaseRef, Partition, Offset, <<MaxI>>} ->
-            lists:unzip(lists:reverse([{Offset, MaxI} | Acc]));
-          {CaseRef, Partition, Offset, <<I>>} when I < MaxI ->
-            F(MaxI, [{Offset, I} | Acc]);
-          Msg ->
-            ct:fail("Unexpected msg: ~p", [Msg])
-        after 5000 ->
-            lists:unzip(lists:reverse(Acc))
-        end
-    end,
-  SendFun(0),
-  %% the first message may or may not be received depending on when
-  %% the consumer starts polling
-  ReceiveFun(0, []),
-  %% send and receive some messages, ack some of them
-  [SendFun(I) || I <- lists:seq(1, 5)],
-  {[_, _, O3, _, O5], [1, 2, 3, 4, 5]} = ReceiveFun(5, []),
-  ok = brod_topic_subscriber:ack(SubscriberPid, Partition, O3),
-  %% do a sync request to the subscriber, so that we know it has
-  %% processed the ack, then kill the brod_consumer process
-  sys:get_state(SubscriberPid),
-  {ok, ConsumerPid} = brod:get_consumer(?CLIENT_ID, ?topic, Partition),
-  Mon = monitor(process, ConsumerPid),
-  exit(ConsumerPid, kill),
-  receive {'DOWN', Mon, process, ConsumerPid, killed} -> ok
-  after 1000 -> ct:fail("timed out waiting for the consumer process to die")
-  end,
-  %% ack all previously received messages
-  %% so topic subscriber can re-subscribe to the restarted consumer
-  ok = brod_topic_subscriber:ack(SubscriberPid, Partition, O5),
-  %% send and receive some more messages, check each message arrives only once
-  [SendFun(I) || I <- lists:seq(6, 8)],
-  {_, [6, 7, 8]} = ReceiveFun(8, []),
-  %% stop the subscriber and check there are no more late messages delivered
-  ok = brod_topic_subscriber:stop(SubscriberPid),
-  receive
-    {CaseRef, Partition, Offset, Value} ->
-      ct:fail("Unexpected msg: offset ~p, value ~p", [Offset, Value])
-  after 0 -> ok
-  end.
+  ?check_trace(
+     %% Run stage:
+     begin
+       {ok, SubscriberPid} =
+         brod:start_link_topic_subscriber(?CLIENT_ID, ?topic, ConsumerConfig,
+                                          ?MODULE, InitArgs),
+       SendFun(0),
+       %% send some messages, ack some of them:
+       [SendFun(I) || I <- lists:seq(1, 5)],
+       {ok, #{offset := O3}} = wait_message(<<3>>),
+       {ok, #{offset := O5}} = wait_message(<<5>>),
+       ok = brod_topic_subscriber:ack(SubscriberPid, Partition, O3),
+       %% do a sync request to the subscriber, so that we know it has
+       %% processed the ack, then kill the brod_consumer process
+       sys:get_state(SubscriberPid),
+       {ok, ConsumerPid} = brod:get_consumer(?CLIENT_ID, ?topic, Partition),
+       kafka_test_helper:kill_process(ConsumerPid),
+       %% ack all previously received messages
+       %% so topic subscriber can re-subscribe to the restarted consumer
+       ok = brod_topic_subscriber:ack(SubscriberPid, Partition, O5),
+       %% send more messages and wait until they are processed:
+       [SendFun(I) || I <- lists:seq(6, 8)],
+       {ok, _} = wait_message(<<8>>),
+       %% stop the subscriber:
+       ok = brod_topic_subscriber:stop(SubscriberPid)
+     end,
+     %% Check stage:
+     fun(_Ret, Trace) ->
+         Expected = [<<I>> || I <- lists:seq(0, 8)],
+         check_received_messages(Expected, Trace),
+         check_state_continuity(Trace)
+     end).
+
+%% Test the old way of consuming messages via callback fun:
+t_cb_fun(Config) when is_list(Config) ->
+  N = 10,
+  Ref = make_ref(),
+  ConsumerConfig = [ {prefetch_count, 10}
+                   , {sleep_timeout, 0}
+                   , {max_wait_time, 1000}
+                   , {partition_restart_delay_seconds, 1}
+                   ],
+  CbFun = fun(Partition, Msg, State) ->
+              #kafka_message{ offset = Offset
+                            , value  = Value
+                            } = Msg,
+              ?tp(topic_subscriber_seen_message,
+                  #{ partition => Partition
+                   , offset    => Offset
+                   , value     => Value
+                   , state     => State
+                   , worker_id => Ref
+                   }),
+              {ok, ack, State + 1}
+          end,
+  InitialState = 0,
+  ?check_trace(
+     %% Run stage:
+     begin
+       %% Produce messages:
+       Messages = [<<I>> || I <- lists:seq(0, N)],
+       [_, _, O3|_] = [produce({?topic, 0}, I) || I <- Messages],
+       %% Start subscriber from offset O+1 and wait until it's done:
+       {ok, SubscriberPid} =
+         brod_topic_subscriber:start_link(?CLIENT_ID, ?topic, [0],
+                                          ConsumerConfig, [{0, O3}], message,
+                                          CbFun, InitialState),
+       ?assertMatch({ok, _}, wait_message(<<N>>)),
+       brod_topic_subscriber:stop(SubscriberPid),
+       Messages
+     end,
+     %% Check stage:
+     fun(Messages, Trace) ->
+         %% Drop messages with offsets =< O3:
+         [_, _, _|Expected] = Messages,
+         check_received_messages(Expected, Trace),
+         check_state_continuity(Trace)
+     end).
+
+%%%_* Internal functions  ======================================================
+
+wait_message(Content) ->
+  wait_message(Content, 30000).
+
+wait_message(Content, Timeout) ->
+  ?block_until(#{ ?snk_kind := topic_subscriber_seen_message
+                , value := Content
+                }, Timeout).
+
+%% Wait for multiple messages and ack them as they are received:
+wait_and_ack(SubscriberPid, Messages) ->
+  [begin
+     {ok, #{offset := Offset}} = wait_message(I),
+     ok = brod_topic_subscriber:ack(SubscriberPid, 0, Offset)
+   end || I <- Messages].
+
+%% Check that messages processed by the tested process are exactly the
+%% same as expected:
+check_received_messages(Expected, Trace) ->
+  Messages = ?of_kind(topic_subscriber_seen_message, Trace),
+  %% Check that all messages have been seen once:
+  ?assertEqual( Expected
+              , ?projection(value, Messages)
+              ).
+
+%% Check that state of callback module is correctly passed around
+%% between the calls:
+check_state_continuity(WorkerId, Trace) ->
+  snabbkaffe:strictly_increasing([S || #{ worker_id := WorkerId
+                                        , state := S
+                                        } <- Trace]).
+
+check_state_continuity(Trace) ->
+  %% Find IDs of all worker processes:
+  Workers = lists:usort([ID || #{ worker_id := ID
+                                , state := _
+                                } <- Trace]),
+  [check_state_continuity(I, Trace) || I <- Workers],
+  true.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/brod_topic_subscriber_SUITE.erl
+++ b/test/brod_topic_subscriber_SUITE.erl
@@ -282,7 +282,7 @@ t_callback_crash(Config) when is_list(Config) ->
             }),
        MRef = monitor(process, SubscriberPid),
        unlink(SubscriberPid),
-       ?inject_crash( #{value := <<2>>, kind := topic_subscriber_seen_message}
+       ?inject_crash( #{value := <<2>>, ?snk_kind := topic_subscriber_seen_message}
                     , snabbkaffe_nemesis:always_crash()
                     ),
        %% Send messages:

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -16,6 +16,7 @@
         , consumer_config/0
         , client_config/0
         , bootstrap_hosts/0
+        , kill_process/1
         ]).
 
 -include("brod_test_macros.hrl").
@@ -179,3 +180,14 @@ consumer_config() ->
 bootstrap_hosts() ->
   [ {"localhost", 9092}
   ].
+
+kill_process(Pid) ->
+  Mon = monitor(process, Pid),
+  ?tp(kill_consumer, #{pid => Pid}),
+  exit(Pid, kill),
+  receive
+    {'DOWN', Mon, process, Pid, killed} ->
+      ok
+  after 1000 ->
+      ct:fail("timed out waiting for the process to die")
+  end.


### PR DESCRIPTION
This PR introduces an optional `brod_group_subscriber_v2` `terminate` callback.