### PR TITLE
Fix unknown types (one typo and one missing export)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,7 @@
 
 {ct_opts, [{enable_builtin_hooks, false}]}.
 
+{dialyzer, [{warnings, [unknown]}]}.
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -81,7 +81,7 @@
 -callback init(brod_group_subscriber_v2:init_info(), _CbConfig) ->
   {ok, _State}.
 
--callback handle_message(brod:kafka_message(), State) ->
+-callback handle_message(brod:message(), State) ->
       {ok, commit, State}
     | {ok, ack, State}
     | {ok, State}.

--- a/src/brod_group_subscriber_worker.erl
+++ b/src/brod_group_subscriber_worker.erl
@@ -41,6 +41,8 @@
         , commit_fun    :: brod_group_subscriber_v2:commit_fun()
         }).
 
+-export_type([start_options/0]).
+
 %%%===================================================================
 %%% brod_topic_subscriber callbacks
 %%%===================================================================

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -59,17 +59,8 @@
 -export_type([ cb_ret/0
              , cb_fun/0
              , committed_offsets/0
+             , topic_subscriber_config/0
              ]).
-
--type topic_subscriber_config_fun() ::
-        #{ client            := brod:client()
-         , topic             := brod:topic()
-         , cb_fun            := module()
-         , message_type      => message | message_set
-         , consumer_config   => brod:consumer_config()
-         , partitions        => all | [brod:partition()]
-         , committed_offsets => brod:committed_offsets()
-         }.
 
 -type topic_subscriber_config() ::
         #{ client            := brod:client()


### PR DESCRIPTION
This PR also enables the `unknown` dialyzer warning to prevent new "unknown types" warnings in the future.
