### PR TITLE
Fix brod_group_subscriber_v2 crash on shutdown

### DIFF
--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -365,7 +365,8 @@ handle_info({'EXIT', Pid, Reason}, State) ->
     [TopicPartition|_] ->
       handle_worker_failure(TopicPartition, Pid, Reason, State);
     _ -> % Other process wants to kill us, supervisor?
-      {stop, shutdown}
+      ?BROD_LOG_INFO("Received EXIT:~p from ~p, shutting down", [Reason, Pid]),
+      {stop, shutdown, State}
   end;
 handle_info(_Info, State) ->
   {noreply, State}.

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -416,6 +416,7 @@ terminate_all_workers(Workers) ->
 terminate_worker(WorkerPid) ->
   case is_process_alive(WorkerPid) of
     true ->
+      unlink(WorkerPid),
       brod_topic_subscriber:stop(WorkerPid);
     false ->
       ok


### PR DESCRIPTION
This PR fixes #438

I believe there is still one possible issue with a termination process: `brod_topic_subscriber:stop` uses `cast(Pid, stop)` + infinite `receive`, but since `brod_topic_subscriber` makes calls to the client module (i.e. `CbModule:handle_message`), it is possible for those calls to hang indefinitely and that would prevent it from processing the `stop` message. Maybe it would make sense to wait for `brod_topic_subscriber`'s graceful shutdown only for so long and then give up and shut it down forcefully. This is not addressed  here.