### PR TITLE
Do not try to format the buffer state when the process abnormally terminates and logs the error

### DIFF
--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -31,6 +31,7 @@
         , handle_info/2
         , init/1
         , terminate/2
+        , format_status/2
         ]).
 
 -export_type([ config/0 ]).
@@ -423,6 +424,15 @@ terminate(Reason, #state{client_pid = ClientPid
       ok
   end,
   ok.
+
+%% @private
+format_status(Opt, [_PDict, State]) ->
+  %% Do not format the buffer attibute when process terminates abnormally and logs an error
+  %% but allow it when is a sys:get_status/1.2
+  case Opt of
+      terminate -> State#state{buffer=opaque_buffer};
+      _ -> [{data, [{"State", State}]}]
+  end.
 
 %%%_* Internal Functions =======================================================
 

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -426,11 +426,14 @@ terminate(Reason, #state{client_pid = ClientPid
   ok.
 
 %% @private
-format_status(Opt, [_PDict, State]) ->
+format_status(Opt, [_PDict, State=#state{buffer = Buffer}]) ->
   %% Do not format the buffer attibute when process terminates abnormally and logs an error
   %% but allow it when is a sys:get_status/1.2
   case Opt of
-      terminate -> State#state{buffer=opaque_buffer};
+      terminate ->
+        %% Drop the data in the buffers so it doesn't get formatted
+        Opaque = brod_producer_buffer:create_opaque_buffer(Buffer),
+        State#state{buffer = Opaque};
       _ -> [{data, [{"State", State}]}]
   end.
 

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -426,16 +426,12 @@ terminate(Reason, #state{client_pid = ClientPid
   ok.
 
 %% @private
-format_status(Opt, [_PDict, State=#state{buffer = Buffer}]) ->
-  %% Do not format the buffer attibute when process terminates abnormally and logs an error
+format_status(normal, [_PDict, State=#state{}]) ->
+  [{data, [{"State", State}]}];
+format_status(terminate, [_PDict, State=#state{buffer = Buffer}]) ->
+  %% Do not format the buffer attribute when process terminates abnormally and logs an error
   %% but allow it when is a sys:get_status/1.2
-  case Opt of
-      terminate ->
-        %% Drop the data in the buffers so it doesn't get formatted
-        Opaque = brod_producer_buffer:create_opaque_buffer(Buffer),
-        State#state{buffer = Opaque};
-      _ -> [{data, [{"State", State}]}]
-  end.
+  State#state{buffer = brod_producer_buffer:empty_buffers(Buffer)}.
 
 %%%_* Internal Functions =======================================================
 

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -24,6 +24,7 @@
         , nack/3
         , nack_all/2
         , maybe_send/3
+        , create_opaque_buffer/1
         ]).
 
 -export([ is_empty/1
@@ -363,6 +364,11 @@ data_size(Data) -> brod_utils:bytes(Data).
 now_ms() ->
   {M, S, Micro} = os:timestamp(),
   ((M * 1000000) + S) * 1000 + Micro div 1000.
+
+-spec create_opaque_buffer(buf()) -> buf().
+create_opaque_buffer(Buffer = #buf{}) ->
+  %% return a buffer without the data in the queues
+  Buffer#buf{pending=?NEW_QUEUE, buffer=?NEW_QUEUE, onwire=[]}.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -24,7 +24,7 @@
         , nack/3
         , nack_all/2
         , maybe_send/3
-        , create_opaque_buffer/1
+        , empty_buffers/1
         ]).
 
 -export([ is_empty/1
@@ -365,9 +365,9 @@ now_ms() ->
   {M, S, Micro} = os:timestamp(),
   ((M * 1000000) + S) * 1000 + Micro div 1000.
 
--spec create_opaque_buffer(buf()) -> buf().
-create_opaque_buffer(Buffer = #buf{}) ->
-  %% return a buffer without the data in the queues
+-spec empty_buffers(buf()) -> buf().
+empty_buffers(Buffer = #buf{}) ->
+  %% return a buffer without the data in the queues but maintaining the counters
   Buffer#buf{pending=?NEW_QUEUE, buffer=?NEW_QUEUE, onwire=[]}.
 
 %%%_* Emacs ====================================================================


### PR DESCRIPTION
Fixes #443. ~~I used `opaque_buffer` atom so it appears in the log and the reader can know why the buffer is not serialized but I'm happy to change it.~~ 
I replaced `opaque_buffer` with a buffer where the list and the queues are empty