### PR TITLE
Fix the exponential growth of the producer buffer

### DIFF
--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -345,7 +345,7 @@ handle_info({'DOWN', _MonitorRef, process, Pid, Reason},
       {ok, NewState} = schedule_retry(State#state{buffer = Buffer}),
       {noreply, NewState#state{connection = ?undef, conn_mref = ?undef}}
   end;
-handle_info({produce, CallRef, Batch, AckCb}, #state{} = State) ->
+handle_info({produce, CallRef, Batch, AckCb}, #state{partition = Partition} = State) ->
   #brod_call_ref{caller = Pid} = CallRef,
   BufCb =
     fun(?buffered) when is_pid(Pid) ->
@@ -363,7 +363,7 @@ handle_info({produce, CallRef, Batch, AckCb}, #state{} = State) ->
                                    },
         erlang:send(Pid, Reply);
        ({?acked, BaseOffset}) when is_function(AckCb, 2) ->
-        AckCb(State#state.partition, BaseOffset)
+        AckCb(Partition, BaseOffset)
     end,
   handle_produce(BufCb, Batch, State);
 handle_info({msg, Pid, #kpro_rsp{ api = produce


### PR DESCRIPTION
Referencing `State#state.partition` from within the `BufCb` fun adds the entire state (including the producer buffer) to the free variables of the fun. Then the fun is added to the producer buffer and in turn to the new version of the state.

This means that when multiple produce requests are buffered, the "flattened size" of the producer buffer will grow exponentially. The observable memory growth of the producer process will be linear, because the old and the new state reference a lot of common terms on the heap. However, when the producer buffer is copied (e.g. when sending it in a message) all those duplicate references lead to creating duplicate copies of the referenced terms, hence the memory need of the message will grow exponentially.

This problem can be easily avoided by making sure only the necessary `partition` field of the state becomes a free variable of the fun.