### PR TITLE
Propagate connect_timeout argument to kpro API functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+* 3.16.2
+  * Propagate `connect_timeout` config to `kpro` API functions as `timeout` arg
+    affected APIs: connect_group_coordinator, create_topics, delete_topics,
+    resolve_offset, fetch, fold, fetch_committed_offsets
 * 3.16.1
   * Fix `brod` script in `brod-cli` in release.
   * Support `rebalance_timeout` consumer group option

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -938,7 +938,8 @@ fetch(Hosts, Topic, Partition, Offset,
 -spec connect_leader([endpoint()], topic(), partition(),
                      conn_config()) -> {ok, pid()}.
 connect_leader(Hosts, Topic, Partition, ConnConfig) ->
-  kpro:connect_partition_leader(Hosts, ConnConfig, Topic, Partition).
+  KproOptions = brod_utils:kpro_connection_options(ConnConfig),
+  kpro:connect_partition_leader(Hosts, ConnConfig, Topic, Partition, KproOptions).
 
 %% @doc List ALL consumer groups in the given kafka cluster.
 %% NOTE: Exception if failed to connect any of the coordinator brokers.
@@ -975,7 +976,8 @@ describe_groups(CoordinatorEndpoint, ConnCfg, IDs) ->
 -spec connect_group_coordinator([endpoint()], conn_config(), group_id()) ->
         {ok, pid()} | {error, any()}.
 connect_group_coordinator(BootstrapEndpoints, ConnCfg, GroupId) ->
-  Args = #{type => group, id => GroupId},
+  KproOptions = brod_utils:kpro_connection_options(ConnCfg),
+  Args = maps:merge(KproOptions, #{type => group, id => GroupId}),
   kpro:connect_coordinator(BootstrapEndpoints, ConnCfg, Args).
 
 %% @doc Fetch committed offsets for ALL topics in the given consumer group.


### PR DESCRIPTION
A number of `kpro` connection functions support a `timeout` argument
which is not provided by `brod` functions.
This makes it use a default timeout of 5 seconds.

Make sure `brod` and `brod_utils` functions use
the `connect_timeout` client config for this argument