### PR TITLE
Declosurize

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-* TBD
+* 3.15.6
   * Eliminate long-lived anonymous function closures
 * 3.15.5
   * Fix exponential growth of `brod_producer` buffer

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 * TBD
+  * Eliminate long-lived anonymous function closures
 * 3.15.5
   * Fix exponential growth of `brod_producer` buffer
 * 3.15.4

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -35,6 +35,7 @@
         ]).
 
 -export([ do_send_fun/4
+        , do_no_ack/2
         ]).
 
 -export_type([ config/0 ]).
@@ -205,7 +206,7 @@ produce(Pid, Key, Value) ->
 -spec produce_no_ack(pid(), brod:key(), brod:value()) -> ok.
 produce_no_ack(Pid, Key, Value) ->
   CallRef = #brod_call_ref{caller = ?undef},
-  AckCb = fun(_, _) -> ok end,
+  AckCb = fun ?MODULE:do_no_ack/2,
   Batch = brod_utils:make_batch_input(Key, Value),
   Pid ! {produce, CallRef, Batch, AckCb},
   ok.
@@ -442,6 +443,8 @@ do_send_fun(ExtraArg, Conn, BatchInput, Vsn) ->
     {error, Reason} ->
       {error, Reason}
   end.
+
+do_no_ack(_Partition, _BaseOffset) -> ok.
 
 -spec log_error_code(topic(), partition(), offset(), brod:error_code()) -> _.
 log_error_code(Topic, Partition, Offset, ErrorCode) ->

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -35,7 +35,7 @@
 -include("brod_int.hrl").
 
 %% keep data in fun() to avoid huge log dumps in case of crash etc.
--type data() :: fun(() -> {brod:key(), brod:value()}).
+-type data() :: fun(() -> [{brod:key(), brod:value()}]).
 -type milli_ts() :: pos_integer().
 -type milli_sec() :: non_neg_integer().
 -type count() :: non_neg_integer().

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -412,8 +412,7 @@ get_sasl_opt(Config) ->
       %% Module should implement kpro_auth_backend behaviour
       {callback, Module, Args};
     {Mechanism, File} when is_list(File) orelse is_binary(File) ->
-      {User, Pass} = read_sasl_file(File),
-      {Mechanism, User, Pass};
+      {Mechanism, File};
     Other ->
       Other
   end.
@@ -740,16 +739,6 @@ get_partition_rsp(Struct) ->
 replace_prop(Key, Value, PropL0) ->
   PropL = proplists:delete(Key, PropL0),
   [{Key, Value} | PropL].
-
-%% Read a regular file, assume it has two lines:
-%% First line is the sasl-plain username
-%% Second line is the password
--spec read_sasl_file(file:name_all()) -> {binary(), binary()}.
-read_sasl_file(File) ->
-  {ok, Bin} = file:read_file(File),
-  Lines = binary:split(Bin, <<"\n">>, [global]),
-  [User, Pass] = lists:filter(fun(Line) -> Line =/= <<>> end, Lines),
-  {User, Pass}.
 
 %% A fetched batch may contain offsets earlier than the
 %% requested begin-offset because the batch might be compressed on

--- a/test/brod_producer_SUITE.erl
+++ b/test/brod_producer_SUITE.erl
@@ -352,10 +352,10 @@ t_produce_batch_callback(Config) when is_list(Config) ->
   Batch = [{K1, V1}, #{key => K2, value => V2}, {<<>>, [{K3, V3}]}],
   Self = self(),
   Ref = make_ref(),
-  Cb = fun(_Partition, _Offset) ->
-           Self ! {Ref, kafka_acked}
-       end,
-  ok = brod:produce_cb(Client, ?TOPIC, Partition, undefined, Batch, Cb),
+  AckCb = fun(_Partition, _Offset) ->
+              Self ! {Ref, kafka_acked}
+          end,
+  ok = brod:produce_cb(Client, ?TOPIC, Partition, undefined, Batch, AckCb),
   receive
     {Ref, kafka_acked} ->
       ok


### PR DESCRIPTION
Brod uses a lot of long-lived anonymous functions, which cause problems during live upgrades. In our case a change in build procedure caused the `brod` .beams to change unexpectedly, causing a lot of `badfun` errors after the upgrade. (If you know `brod` will be upgraded you can stop and restart it, but in this case we didn't know.)

To avoid these issues this changes several callback functions to accept a `{Fun, Arg}` representation. At the call sites, `Arg` is prepended to the list of actual parameters. This allows us to use exported functions, `fun Module:Fun/N`, as the callbacks, making the code live-upgrade safe.

In two cases the code wrapped data in functions to hide it from crash logs, but that isn't necessary any more.