### PR TITLE
Add join_group rebalance_timeout_ms field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 3.16.1
+  * Fix `brod` script in `brod-cli` in release.
+  * Support `rebalance_timeout` consumer group option
 * 3.16.0
   * Update to kafka-protocol v4.0.1
 * 3.15.6

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -49,7 +49,7 @@
 
 %% default configs
 -define(SESSION_TIMEOUT_SECONDS, 30).
--define(REBALANCE_TIMEOUT_SECONDS, 2).
+-define(REBALANCE_TIMEOUT_SECONDS, ?SESSION_TIMEOUT_SECONDS).
 -define(HEARTBEAT_RATE_SECONDS, 5).
 -define(PROTOCOL_TYPE, <<"consumer">>).
 -define(MAX_REJOIN_ATTEMPTS, 5).
@@ -132,7 +132,7 @@
           %% The referece of the timer which triggers offset commit
         , offset_commit_timer :: ?undef | reference()
 
-          %% configs, see start_link/5 doc for details
+          %% configs, see start_link/6 doc for details
         , partition_assignment_strategy  :: partition_assignment_strategy()
         , session_timeout_seconds        :: pos_integer()
         , rebalance_timeout_seconds      :: pos_integer()
@@ -182,7 +182,7 @@
 %%        partitions.</li>
 %%  </ul></li>
 %%
-%%  <li>`session_timeout_seconds' (optional, default = 10)
+%%  <li>`session_timeout_seconds' (optional, default = 30)
 %%
 %%      Time in seconds for the group coordinator broker to consider a member
 %%      'down' if no heartbeat or any kind of requests received from a broker
@@ -190,7 +190,15 @@
 %%      A group member may also consider the coordinator broker 'down' if no
 %%      heartbeat response response received in the past N seconds.</li>
 %%
-%%  <li>`heartbeat_rate_seconds' (optional, default = 2)
+%%
+%%  <li>`rebalance_timeout_seconds' (optional, default = 30)
+%%
+%%      Time in seconds for each worker to join the group once a rebalance
+%%      has begun. If the timeout is exceeded, then the worker will be
+%%      removed from the group, which will cause offset commit failures.</li>
+%%
+%%
+%%  <li>`heartbeat_rate_seconds' (optional, default = 5)
 %%
 %%      Time in seconds for the member to 'ping' the group coordinator.
 %%      OBS: Care should be taken when picking the number, on one hand, we do

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -49,6 +49,7 @@
 
 %% default configs
 -define(SESSION_TIMEOUT_SECONDS, 30).
+-define(REBALANCE_TIMEOUT_SECONDS, 3).
 -define(HEARTBEAT_RATE_SECONDS, 5).
 -define(PROTOCOL_TYPE, <<"consumer">>).
 -define(MAX_REJOIN_ATTEMPTS, 5).
@@ -599,9 +600,11 @@ join_group(#state{ groupId                 = GroupId
     , {metadata, Meta}
     ],
   SessionTimeout = timer:seconds(SessionTimeoutSec),
+  RebalanceTimeout = timer:seconds(?REBALANCE_TIMEOUT_SECONDS),
   Body =
     [ {group_id, GroupId}
     , {session_timeout_ms, SessionTimeout}
+    , {rebalance_timeout_ms, RebalanceTimeout}
     , {member_id, MemberId0}
     , {protocol_type, ?PROTOCOL_TYPE}
     , {protocols, [Protocol]}

--- a/src/brod_kafka_apis.erl
+++ b/src/brod_kafka_apis.erl
@@ -146,7 +146,7 @@ supported_versions(API) ->
     offset_commit    -> {2, 2};
     offset_fetch     -> {1, 2};
     find_coordinator -> {0, 0};
-    join_group       -> {0, 0};
+    join_group       -> {0, 1};
     heartbeat        -> {0, 0};
     leave_group      -> {0, 0};
     sync_group       -> {0, 0};


### PR DESCRIPTION
When using [Vectorized Redpanda](https://vectorized.io/redpanda/) as the Kafka broker we've run into an issue with consumer group stabilisation. My research has lead to the `join_group` request not carrying `rebalance_timeout_ms` value, which in turn lead to [`rebalance_timeout()` computation on Redpanda side returning -1](https://github.com/vectorizedio/redpanda/blob/a8d19c32c95c2c313e7eea69defc058a8b269e2b/src/v/kafka/server/group.cc#L251-L264). Each time a consumer wanted to join an existing group a rebalance would be started, but with the timeout value of -1 existing members wouldn't have time to rejoin. This would lead to the kicked out members retrying to join the group, which in turn would rebalance again and kick out previously joining members. This would loop indefinitely.

With this fix applied, Redpanda doesn't use -1 as the group join timeout, therefore the group stabilises as expected. I've contacted them about considering using a more reasonable default, if `join_group` request doesn't carry `rebalance_timeout_ms`.

In the meantime, I think this fix might be useful to other Brod users.