### PR TITLE
fix: describe_groups schema

### DIFF
--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -504,7 +504,7 @@ list_groups(Endpoint, ConnCfg) ->
 describe_groups(CoordinatorEndpoint, ConnCfg, IDs) ->
   with_conn([CoordinatorEndpoint], ConnCfg,
     fun(Pid) ->
-        Req = kpro:make_request(describe_groups, 0, [{group_ids, IDs}]),
+        Req = kpro:make_request(describe_groups, 0, [{groups, IDs}]),
         request_sync(Pid, Req)
     end).
 


### PR DESCRIPTION
The command describe_groups in brod_cli is passing a wrong parameter `group_ids`, when the required schema in kafka_protocol is `groups`

Error when running:
./_build/brod_cli/rel/brod/bin/brod groups --ids=hello_kafka_group -b 127.0.0.1:9092

```erlang
*** error:{field_missing,[{stack,[{describe_groups,0},groups]},
                          {input,[{group_ids,[<<"hello_kafka_group">>]}]}]}
[{kpro_req_lib,enc_struct,3,
               [{file,"/home/eduardo/dev/brod/_build/default/lib/kafka_protocol/src/kpro_req_lib.erl"},
                {line,459}]},
 {kpro_req_lib,encode_struct,3,
               [{file,"/home/eduardo/dev/brod/_build/default/lib/kafka_protocol/src/kpro_req_lib.erl"},
                {line,439}]},
 {kpro_req_lib,make,3,
               [{file,"/home/eduardo/dev/brod/_build/default/lib/kafka_protocol/src/kpro_req_lib.erl"},
                {line,393}]},
 {brod_utils,'-describe_groups/3-fun-0-',2,
             [{file,"/home/eduardo/dev/brod/src/brod_utils.erl"},{line,507}]},
 {kpro_brokers,with_connection,3,
               [{file,"/home/eduardo/dev/brod/_build/default/lib/kafka_protocol/src/kpro_brokers.erl"},
                {line,65}]},
 {brod_cli,do_describe_cgs,3,
           [{file,"/home/eduardo/dev/brod/src/brod_cli.erl"},{line,689}]},
 {brod_cli,describe_cgs,3,
           [{file,"/home/eduardo/dev/brod/src/brod_cli.erl"},{line,683}]},
 {brod_cli,main,5,
           [{file,"/home/eduardo/dev/brod/src/brod_cli.erl"},{line,392}]}]
```
           
This PR fixes this.