### PR TITLE
Sdc/rm rebar2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,31 @@
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, deprecated_function_calls,
                deprecated_functions]}.
+{profiles, [
+  {brod_cli, [
+    {deps, [ {docopt, {git, "https://github.com/zmstone/docopt-erl.git", {branch, "0.1.3"}}}
+           , {jsone, "1.7.0"}
+    ]},
+    {erl_opts, [{d, build_brod_cli}]},
+    {escript_name, brod_cli},
+    {relx, [{release, {brod, "i"}, % release the interactive shell as brod-i
+      [brod, jsone, docopt]},
+      {include_erts, true},
+      {overlay, [{copy, "scripts/brod", "bin"},
+        {copy, "{{lib_dirs}}/crc32cer/priv/crc32cer*.so", "bin"},
+        {copy, "{{lib_dirs}}/snappyer/priv/snappyer.so", "bin"}
+      ]}
+    ]}]},
+  {test, [
+    {deps, [ {docopt, {git, "https://github.com/zmstone/docopt-erl.git", {branch, "0.1.3"}}}
+           , {jsone, "1.7.0"}
+           , {meck, "0.9.2"}
+           , {proper, "1.4.0"}
+           , {snabbkaffe, "0.6.0"}
+    ]},
+    {erl_opts, [{d, build_brod_cli}]}
+  ]}
+]}.
 {ex_doc,
   [ {extras,
     [ {"changelog.md", #{title => "Changelog"}}
@@ -27,14 +52,10 @@
     , {api_reference, false}
   ]}.
 {hex, [{doc, ex_doc}]}.
-
 {escript_incl_apps, [docopt, brod]}.
-
 {ct_opts, [{enable_builtin_hooks, false}]}.
-
 {dialyzer, [{warnings, [unknown]}]}.
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
-
 {plugins, [coveralls]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,68 +1,22 @@
-IsRebar3 = erlang:function_exported(rebar3, main, 1),
-DocoptUrl = "https://github.com/zmstone/docopt-erl.git",
-DocOptTag = "0.1.3",
-DocoptDep = {docopt, {git, DocoptUrl, {branch, DocOptTag}}},
-Snabbkaffe = {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "0.6.0"}}},
 Plugins =
   case erlang:list_to_integer(erlang:system_info(otp_release)) of
     Version when Version > 23 ->
-      {project_plugins, [{rebar3_ex_doc, "~> 0.2.9"},{rebar3_hex, "~> 7.0.1"},{rebar3_lint, "~> 1.0.2"}]};
-    _ -> {project_plugins, [{rebar3_lint, "~> 1.0.2"}]}
+      ExtraPlugins = [{rebar3_ex_doc, "~> 0.2.9"},{rebar3_hex, "~> 7.0.1"}],
+      {project_plugins, lists:merge(ExtraPlugins, proplists:get_value(project_plugins, CONFIG))};
+    _ -> {project_plugins, proplists:get_value(project_plugins, CONFIG)}
   end,
-Profiles =
-  {profiles, [
-    {brod_cli, [
-      {deps, [jsone, DocoptDep]},
-      {erl_opts, [{d, build_brod_cli}]},
-      {escript_name, brod_cli},
-      {relx, [{release, {brod, "i"}, % release the interactive shell as brod-i
-               [brod, jsone, docopt]},
-              {include_erts, true},
-              {overlay, [{copy, "scripts/brod", "bin"},
-                         {copy, "{{lib_dirs}}/crc32cer/priv/crc32cer*.so", "bin"},
-                         {copy, "{{lib_dirs}}/snappyer/priv/snappyer.so", "bin"}
-                        ]}
-             ]}]},
-    {test, [
-      {deps, [meck, proper, jsone, DocoptDep, Snabbkaffe]},
-      {erl_opts, [{d, build_brod_cli}]}
-    ]}
-  ]},
-CONFIG1 = case IsRebar3 of
-  true ->
-    [Plugins | [Profiles | CONFIG]];
-  false ->
-    URLs = [ {supervisor3, "https://github.com/kafka4beam/supervisor3.git"}
-           , {kafka_protocol, "https://github.com/kafka4beam/kafka_protocol.git"}
-           ],
-    Rebar3Deps = proplists:get_value(deps, CONFIG),
-    Rebar2Deps =
-      lists:map(
-        fun({Name, URL}) ->
-          case proplists:get_value(Name, Rebar3Deps) of
-            {git, _, _} = Git -> {Name, ".*", Git};
-            Vsn               -> {Name, ".*", {git, URL, {tag, Vsn}}}
-          end
-        end, URLs),
-   [Plugins | lists:keyreplace(deps, 1, CONFIG, {deps, Rebar2Deps})]
-end,
-
-case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
+CoverallsConfigs = case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
   {"true", Token} when is_list(Token) ->
-    CONFIG2 = [Plugins,
-               {coveralls_repo_token, Token},
+    Configs = [{coveralls_repo_token, Token},
                {coveralls_coverdata, "_build/test/cover/*.coverdata"},
                {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
                {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
                {coveralls_service_name, "github"},
-               {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")} | CONFIG1],
-    case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
-      andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
-      [_, "pull", PRNO, _] ->
-        [{coveralls_service_pull_request, PRNO} | CONFIG2];
-      _ ->
-        CONFIG2
+               {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")}],
+    case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request" andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
+      [_, "pull", PRNO, _] -> [{coveralls_service_pull_request, PRNO} | Configs];
+      _ -> Configs
     end;
-  _ ->
-    CONFIG1
-end.
+  _ -> []
+end,
+[Plugins | lists:merge(CoverallsConfigs, CONFIG)].


### PR DESCRIPTION
I was iterating on the `rebar.config` and `rebar.config.script` and realized that the CI is always using rebar3, even with OTP 23.3.4.7 so I think we can clean it up a bit.  This MR will be a lot easier to review once https://github.com/kafka4beam/brod/pull/499 is merged.
<img width="790" alt="Screen Shot 2022-05-06 at 3 56 13 PM" src="https://user-images.githubusercontent.com/1206303/167221455-587e1147-9bad-4ff6-a5ab-56671eeb368e.png">

