### PR TITLE
Expose consumer 'isolation_level'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 * 3.16.3
   * Fix specs for `delete_topics`.
   * Ensure that partition worker process is alive before returning it.
+  * Make consumer 'isolation_level' configurable.
 * 3.16.2
   * Update kafka_protocol from 4.0.1 to 4.0.3.
     Prior to this change the actual time spent in establishing a

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -186,6 +186,14 @@ start_link(Bootstrap, Topic, Partition, Config) ->
 %%     a relatively small `max_bytes', then let it dynamically adjust
 %%     to a number around `PrefetchCount * AverageSize'</li>
 %%
+%%  <li>`isolation_level': (optional, default = `read_commited')
+%%
+%%     Level to control what transaction records are exposed to the
+%%     consumer. Two values are allowed, `read_uncommitted' to retrieve
+%%     all records, independently on the transaction outcome (if any),
+%%     and `read_committed' to get only the records from committed
+%%     transactions</li>
+%%
 %% </ul>
 %% @end
 -spec start_link(pid() | brod:bootstrap(),

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -19,7 +19,7 @@
 
 -export([ create_topics/3
         , delete_topics/3
-        , fetch/7
+        , fetch/8
         , list_groups/1
         , list_offsets/4
         , join_group/2
@@ -77,14 +77,16 @@ delete_topics(Vsn, Topics, Timeout) ->
 %% @doc Make a fetch request, If the first arg is a connection pid, call
 %% `brod_kafka_apis:pick_version/2' to resolve version.
 -spec fetch(conn(), topic(), partition(), offset(),
-            kpro:wait(), kpro:count(), kpro:count()) -> kpro:req().
+            kpro:wait(), kpro:count(), kpro:count(),
+            kpro:isolation_level()) -> kpro:req().
 fetch(Pid, Topic, Partition, Offset,
-      WaitTime, MinBytes, MaxBytes) ->
+      WaitTime, MinBytes, MaxBytes, IsolationLevel) ->
   Vsn = pick_version(fetch, Pid),
   kpro_req_lib:fetch(Vsn, Topic, Partition, Offset,
                      #{ max_wait_time => WaitTime
                       , min_bytes => MinBytes
                       , max_bytes => MaxBytes
+                      , isolation_level => IsolationLevel
                       }).
 
 %% @doc Make a `list_offsets' request message for offset resolution.

--- a/test/brod_consumer_SUITE.erl
+++ b/test/brod_consumer_SUITE.erl
@@ -467,10 +467,11 @@ t_consumer_max_bytes_too_small(Config) ->
   MaxBytes2 = 12, %% too small but message size is fetched
   MaxBytes3 = size(Key) + ValueBytes,
   Tester = self(),
-  F = fun(Conn, Topic, Partition1, BeginOffset, MaxWait, MinBytes, MaxBytes) ->
+  F = fun(Conn, Topic, Partition1, BeginOffset, MaxWait,
+          MinBytes, MaxBytes, IsolationLevel) ->
         Tester ! {max_bytes, MaxBytes},
         meck:passthrough([Conn, Topic, Partition1, BeginOffset,
-                          MaxWait, MinBytes, MaxBytes])
+                          MaxWait, MinBytes, MaxBytes, IsolationLevel])
       end,
   %% Expect the fetch_request construction function called twice
   meck:expect(brod_kafka_request, fetch, F),


### PR DESCRIPTION
## Description

Consumers always use `read_commited` isolation level whether transactions are being used or not. 

`kafka_protocol` already supports this option so this PR just allows it to be provided as an option to a `fetch` or as a configuration parameter to a consumer.

__NOTE__: I didn't find any specifics regarding contributions in this repository, please let me know if I missed something and I will any required steps.