### PR TITLE
Update Publisher.md

### DIFF
--- a/guides/examples/elixir/Publisher.md
+++ b/guides/examples/elixir/Publisher.md
@@ -54,7 +54,8 @@ When providing `:hash` as the _partition_ when calling `:brod.produce_sync/5` is
 
 ```elixir
 {:ok, count} = :brod.get_partitions_count(:kafka_client, topic)
-:brod.produce_sync(:kafka_client, topic, :erlang.phash2(key, count), key, message)
+partition = rem(:erlang.phash2(key), count)
+:brod.produce_sync(:kafka_client, topic, partition, key, message)
 ```
 
 Internally brod will get the partition count, generate a hash for the key within the range of partitions,


### PR DESCRIPTION
Correcting hash partition calculation example to align with implementation.
```
$ iex
Erlang/OTP 25 [erts-13.0.2] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit:ns]
Interactive Elixir (1.13.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> :erlang.phash2("foo", 3)
0
iex(2)> rem(:erlang.phash2("foo"), 3) 
1
```