### PR TITLE
Fix `get_committed_offset` return specs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 3.16.5
+  * Fix specs for `get_committed_offset`
 * 3.16.4
   * Update kafka_protocol from 4.0.3 to 4.1.0. kafka_protocol 4.1.0 support a
     different version of the auth plugin interface that also pass the

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 * 3.16.5
-  * Fix specs for `get_committed_offset`
+  * Fix specs for `brod_group_subscriber_v2.get_committed_offset`
 * 3.16.4
   * Update kafka_protocol from 4.0.3 to 4.1.0. kafka_protocol 4.1.0 support a
     different version of the auth plugin interface that also pass the

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -88,7 +88,7 @@
 
 %% Get committed offset (in case it is managed by the subscriber):
 -callback get_committed_offset(_CbConfig, brod:topic(), brod:partition()) ->
-  {ok, brod:offset() | undefined}.
+  {ok, brod:offset()} | undefined.
 
 %% Assign partitions (in case `partition_assignment_strategy' is set
 %% for `callback_implemented' in group config).


### PR DESCRIPTION
Fix specs according to expected format in: https://github.com/kafka4beam/brod/blob/f88130e051fc2e317e744217f9e05071378d4629/src/brod_group_subscriber_v2.erl#L281