### PR TITLE
feat: allow special offsets from consumer managed commits

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 * 3.16.4
+  * Allow special begin_offset from consumer managed commits.
   * Fix specs for `brod_group_subscriber_v2.get_committed_offset`
   * Update kafka_protocol from 4.0.3 to 4.1.0. kafka_protocol 4.1.0 support a
     different version of the auth plugin interface that also pass the

--- a/include/brod.hrl
+++ b/include/brod.hrl
@@ -60,7 +60,7 @@
 -record(brod_received_assignment,
         { topic        :: brod:topic()
         , partition    :: brod:partition()
-        , begin_offset :: undefined | brod:offset()
+        , begin_offset :: undefined | brod:offset() | {begin_offset, brod:offset_time()}
         }).
 
 -type brod_received_assignments() :: [#brod_received_assignment{}].

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -203,7 +203,7 @@
 -type client_config() :: brod_client:config().
 -type bootstrap() :: [endpoint()] %% default client config
                    | {[endpoint()], client_config()}.
--type offset_time() :: integer()
+-type offset_time() :: offset()
                      | ?OFFSET_EARLIEST
                      | ?OFFSET_LATEST.
 -type message() :: kpro:message().

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -88,7 +88,7 @@
 
 %% Get committed offset (in case it is managed by the subscriber):
 -callback get_committed_offset(_CbConfig, brod:topic(), brod:partition()) ->
-  {ok, brod:offset()} | undefined.
+  {ok, brod:offset() | {begin_offset, brod:offset_time()}} | undefined.
 
 %% Assign partitions (in case `partition_assignment_strategy' is set
 %% for `callback_implemented' in group config).

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -212,9 +212,6 @@ assignments_revoked(Pid) ->
 %%
 %% NOTE: This function is called only when `offset_commit_policy' is set to
 %%       `consumer_managed' in group config.
-%%
-%% NOTE: The committed offsets should be the offsets for successfully processed
-%%       (acknowledged) messages, not the `begin_offset' to start fetching from.
 %% @end
 -spec get_committed_offsets(pid(), [brod:topic_partition()]) ->
         {ok, [{brod:topic_partition(), brod:offset()}]}.

--- a/test/brod_test_group_subscriber.erl
+++ b/test/brod_test_group_subscriber.erl
@@ -69,7 +69,8 @@ handle_message(Message,
   end.
 
 get_committed_offset(_CbConfig, _Topic, _Partition) ->
-  {ok, {begin_offset, latest}}.
+  %% always return undefined: always fetch from latest available offset
+  ?undef.
 
 assign_partitions(_CbConfig, Members, TopicPartitions) ->
   PartitionsAssignments = [{Topic, [PartitionsN]}

--- a/test/brod_test_group_subscriber.erl
+++ b/test/brod_test_group_subscriber.erl
@@ -69,8 +69,7 @@ handle_message(Message,
   end.
 
 get_committed_offset(_CbConfig, _Topic, _Partition) ->
-  %% always return undefined: always fetch from latest available offset
-  undefined.
+  {ok, {begin_offset, latest}}.
 
 assign_partitions(_CbConfig, Members, TopicPartitions) ->
   PartitionsAssignments = [{Topic, [PartitionsN]}


### PR DESCRIPTION
fixes: https://github.com/kafka4beam/brod/issues/517

Prior to this change, consumer_managed group-member implementation can 
only return `[{{Topic, Partition}, LastConsumedOffset}]` from the `get_committed_offsets` callback.

In conjunction with a bug in `brod_group_subscriber_worker`, it caused trouble for users who
wish to reset begin offset to `earliest` or `latest` from this return value.

With this fix, now it can return `[{{Topic, Partition},{begin_offset, earliest | latest | AnyOffset}}]`
to instruct `brod_consumer` start fetching from the exact desired offset.