### PR TITLE
Use master as source_ref for ExDoc

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -50,6 +50,7 @@
     , {main, "README.md"}
     , {homepage_url, "https://hexdocs.pm/brod"}
     , {source_url, "https://github.com/kafka4beam/brod"}
+    , {source_ref, "master"}
     , {api_reference, false}
   ]}.
 {hex, [{doc, ex_doc}]}.


### PR DESCRIPTION
This affects links from ExDoc to the source code.
The links are now broken as rebar3_ex_doc assumes
that Git tags start with 'v'.

Using master branch for links is not optimal because the code may differ from the latest released version but I think it's better than non-working links.

See: https://github.com/starbelly/rebar3_ex_doc/issues/18