### PR TITLE
feat(group_subscriber_v2): add `get_wokers` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - 3.16.8
   - Upgrade `supervisor3` from 1.1.11 to 1.1.12 to log supervisor status
     at `debug` level instead of `notice` level.
+  - Add `brod_group_subscriber_v2:get_workers` function to help
+    monitor and check the health of a consumer group.
 
 - 3.16.7
   - Upgrade `kafka_protocol` from 4.1.1 to 4.1.2 to allow handling

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -50,6 +50,7 @@
         , t_async_commit/1
         , t_consumer_crash/1
         , t_assign_partitions_handles_updating_state/1
+        , t_get_workers/1
         , v2_coordinator_crash/1
         , v2_subscriber_shutdown/1
         , v2_subscriber_assignments_revoked/1
@@ -94,6 +95,7 @@ groups() ->
      , t_2_members_one_partition
      , t_async_commit
      , t_assign_partitions_handles_updating_state
+     , t_get_workers
      , v2_coordinator_crash
      , v2_subscriber_shutdown
      , v2_subscriber_assignments_revoked
@@ -278,6 +280,31 @@ t_async_acks(Config) when is_list(Config) ->
      fun(L, Trace) ->
          check_all_messages_were_received_once(Trace, L)
      end).
+
+t_get_workers(Config) when is_list(Config) ->
+  case ?config(behavior) of
+     brod_group_subscriber_v2 ->
+      %% only present in v2
+      InitArgs = #{async_ack => true},
+      Topic = ?topic,
+      ?check_trace(
+         #{ timeout => 10000 },
+         %% Run stage:
+         begin
+           {ok, SubscriberPid} = start_subscriber(?group_id, Config, [Topic], InitArgs),
+           ct:sleep(2000),
+           brod_group_subscriber_v2:get_workers(SubscriberPid)
+         end,
+         %% Check stage:
+         fun(Workers, _Trace) ->
+             ct:pal("result: ~p", [Workers]),
+             ?assert(is_map(Workers)),
+             ?assert(lists:all(fun is_pid/1, maps:values(Workers))),
+             ok
+         end);
+    _ ->
+      ok
+  end.
 
 t_consumer_crash(Config) when is_list(Config) ->
   %% use consumer managed offset commit behaviour


### PR DESCRIPTION
A `brod` subscriber group is only truly healthy if _at least_ we have connections to the partition leaders for a topic _and_ all the group subscriber workers are present and alive.  To help check the health of the subscriber group, we add this `get_workers` function.