### PR TITLE
fix: Extracts coveralls from `plugins` list to `project_plugins`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {deps, [ {kafka_protocol, "4.1.2"}
        , {snappyer, "1.2.9"}
        ]}.
-{project_plugins, [{rebar3_lint, "~> 1.0.2"}]}.
+{project_plugins, [{coveralls, "~> 2.2.0"}, {rebar3_lint, "~> 1.0.2"}]}.
 {edoc_opts, [{preprocess, true}, {macros, [{build_brod_cli, true}]}]}.
 {erl_opts, [warnings_as_errors, warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.
 {xref_checks, [undefined_function_calls, undefined_functions,
@@ -59,4 +59,4 @@
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
-{plugins, [coveralls]}.
+{plugins, []}.


### PR DESCRIPTION
Coveralls isn't a plugin needed for the function of the library, so moving it to the `project_plugins` portion will prevent Elixir projects from making a network call when compiling to library after this is merged.

Currently this means we can't release new versions of our app that uses this library, but this change should be pretty straightforward to rubber stamp.