### PR TITLE
fix: type spec of v2 group consumer handle_message

### DIFF
--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -84,7 +84,7 @@
 -callback init(brod_group_subscriber_v2:init_info(), _CbConfig) ->
   {ok, _State}.
 
--callback handle_message(brod:message(), State) ->
+-callback handle_message(brod:message() | brod:message_set(), State) ->
       {ok, commit, State}
     | {ok, ack, State}
     | {ok, State}.


### PR DESCRIPTION
Given that brod_topic_subscriber callback is typed as below and brod_group_subscriber_worker implements brod_topic_subscriber, it will pass on brod:message_set to v2 group consumers.

```
-callback handle_message(brod:partition(),
                         brod:message() | brod:message_set(),
                         cb_state()) -> cb_ret().
```

So the brod_group_subscriber_v2 behavior should probably be typed to be either message or message_set too.