### PR TITLE
Change supervisor3 info to debug logger level

### DIFF
--- a/src/brod_supervisor3.erl
+++ b/src/brod_supervisor3.erl
@@ -1586,4 +1586,4 @@ extract_child_common(Child) ->
 report_progress(Child, SupName) ->
     Progress = [{supervisor, SupName},
                 {started, extract_child(Child)}],
-    error_logger:info_report(progress, Progress).
+    logger:log(debug, Progress).


### PR DESCRIPTION
This PR changes the supervisor3's logger level that has been done for some `supvervisor3` package version but when it got transfered to `brod` it got stripped (probably old version).