### PR TITLE
chore: upgrade to kafka_protocol from 4.1.3 to 4.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- 3.17.1
+  - Upgrade `kafka_protocol` from 4.1.3 to 4.1.5
+    - Allow space after `,` in comma-separated bootstrapping host:port list
+    - Avoid `badmatch` exception when parsing SASL password file
+
 - 3.17.0
   - Deleted `supervisor3` as dependency, module is now moved to brod.git named `brod_supervisor3`.
   - Upgrade `snappyer` version from 1.2.8 to 1.2.9.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [ {kafka_protocol, "4.1.3"}
+{deps, [ {kafka_protocol, "4.1.5"}
        , {snappyer, "1.2.9"}
        ]}.
 {project_plugins, [{coveralls, "~> 2.2.0"}, {rebar3_lint, "~> 1.0.2"}]}.


### PR DESCRIPTION
Included changes are:
- Allow space after `,` in comma-separated bootstrapping host:port list
- Avoid `badmatch` exception when parsing SASL password file