### PR TITLE
Remove unused macros (as detected by ELP)

### DIFF
--- a/src/brod_cli_pipe.erl
+++ b/src/brod_cli_pipe.erl
@@ -56,7 +56,6 @@
 -define(LINE_BREAK, <<"\n">>).
 -define(STDIN, standard_io).
 -define(EOF_RETRY_DELAY_MS, 100).
--define(NOT_APPLICABLE, 'N/A').
 -define(CONTINUE_MSG, continue).
 -define(PARENT_BUSY_MSG_QUEUE_LEN_THRESHOLD, 100).
 

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -130,7 +130,6 @@
 %% so prefetch-count can dominate fetch-ahead limit
 -define(DEFAULT_PREFETCH_BYTES, 102400). % 100 KB
 -define(DEFAULT_OFFSET_RESET_POLICY, reset_by_subscriber).
--define(ERROR_COOLDOWN, 1000).
 -define(CONNECTION_RETRY_DELAY_MS, 1000).
 
 -define(SEND_FETCH_REQUEST, send_fetch_request).

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -40,7 +40,6 @@
 -type offset() :: brod:offset().
 -type conn() :: kpro:connection().
 
--define(MIN_MAGIC_2_PRODUCE_API_VSN, 3).
 
 %% @doc Make a produce request, If the first arg is a connection pid, call
 %% `brod_kafka_apis:pick_version/2' to resolve version.

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -517,7 +517,6 @@ describe_groups(CoordinatorEndpoint, ConnCfg, IDs) ->
         request_sync(Pid, Req)
     end).
 
--define(IS_BYTE(I), (I>=0 andalso I<256)).
 
 %% @doc Return message set size in number of bytes.
 %% NOTE: This does not include the overheads of encoding protocol.


### PR DESCRIPTION
While investigating WhatsApp/erlang-language-platform#13, I used the [ELP](https://whatsapp.github.io/erlang-language-platform/) language server to navigate the `brod` code base. The language server complained about a few unused macros, so the content of this PR is the result of:

```
elp lint --diagnostic-filter unused_macro --apply-fix --in-place
```

Which auto-removes unused macros from the code base.