### PR TITLE
Proposal: Forward unhandled messages to optional subscriber handle_info callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- 3.19.0
+  - Forward unhandled messages in topic/group consumer processes to handle_info/2 callbacks
+    in order to support arbitrary message passing [PR#580](https://github.com/kafka4beam/brod/pull/580) 
+
 - 3.18.0
   - Add transactional APIs. [PR#549](https://github.com/kafka4beam/brod/pull/549)
   - Fix unnecessary group coordinator restart due to `hb_timeout` exception. [PR#578](https://github.com/kafka4beam/brod/pull/578)


### PR DESCRIPTION
First of all, thanks for the excellent library. 
Let me know if the motivation is unclear and whether you find this to be a sensible addition.

The motivation for adding handle_info callbacks is to allow subscriber worker processes which are spawned by brod to participate in message passing, supporting a variety of use cases utilizing async acking and committing.

An example use case:
* Start a group subscriber using `brod_group_subscriber_v2`
* In a partition worker spawn a new process for every message under a supervisor specific to the worker's topic-partition
* When the supervisor has <= N processes, ack last seen offset to fetch new messages. When the supervisor has > N processes, messages are not acked to apply backpressure
* When all processes up to offset O1 have completed, commit offset O1

Allowing arbitrary message passing in the topic and group subscriber workers supports not only that use case but many others.