### PR TITLE
Guard against undefined partition worker pid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 3.19.1
+  - Guard against crashes in `brod_client:get_consumer/3` [PR#581](https://github.com/kafka4beam/brod/pull/581)
+
 - 3.19.0
   - Forward unhandled messages in topic/group consumer processes to handle_info/2 callbacks
     in order to support arbitrary message passing [PR#580](https://github.com/kafka4beam/brod/pull/580) 

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -493,7 +493,7 @@ get_partition_worker(ClientId, Key) when is_atom(ClientId) ->
       %% If the worker process is returned form ets,
       %% but it is not alive then there must be
       %% an in-flight worker deregistration request.
-      case is_process_alive(Pid) of
+      case is_pid(Pid) andalso is_process_alive(Pid) of
         true -> {ok, Pid};
         false -> get_partition_worker_with_ets(ClientId, Key)
       end;


### PR DESCRIPTION
I've observed a data race when starting a consumer from within another consumer (using co-partitioned topics), where the call to `get_partition_worker` fails due to badarg in `is_process_alive`.

It seems that 1f2290b ("Verify partition worker process is alive.", 2022-05-19) already tried to resolve the data race, but did not consider the possibility that the lookup returns `undefined`.

Example exit report from Elixir logger:
```
Last message: {:EXIT, #PID<0.2613.0>, {:badarg, [{:erlang, :is_process_alive, [:undefined], [error_info: %{module: :erl_erts_errors}]}, {:brod_client, :get_partition_worker, 2, [file: ~c"/app/deps/brod/src/brod_client.erl", line: 496]}, ...MyCallChain]}}
```