### PR TITLE
Expose ack_fun through the init_info

### DIFF
--- a/src/brod_group_subscriber_worker.erl
+++ b/src/brod_group_subscriber_worker.erl
@@ -32,6 +32,7 @@
          , cb_module    := module()
          , cb_config    := term()
          , commit_fun   := brod_group_subscriber_v2:commit_fun()
+         , ack_fun      := brod_group_subscriber_v2:ack_fun()
          }.
 
 -record(state,
@@ -54,7 +55,7 @@ init(Topic, StartOpts) ->
    , begin_offset := BeginOffset
    , commit_fun   := CommitFun
    } = StartOpts,
-  InitInfo = maps:with( [topic, partition, group_id, commit_fun]
+  InitInfo = maps:with( [topic, partition, group_id, commit_fun, ack_fun]
                       , StartOpts
                       ),
   ?BROD_LOG_INFO("Starting group_subscriber_worker: ~p~n"


### PR DESCRIPTION
`commit_fun` is already exposed, but `ack_fun` is not. This is useful when acking does not happen inside the worker process.

E.g. We divide messages between multiple processes and later in a separate process we create a transaction and commit a batch. Now we need to let the consumer know that it's okay to fetch more messages.

I briefly considered adding tests for this but wasn't sure how to do it. I've manually tested it, and it works. It follows the same pattern as commit_fun.