### PR TITLE
feat: add boolean flag 'share_leader_conn' in consumer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- 4.2.0
+  - Optimize consumer fetch latency.
+    Introduced the `share_leader_conn` consumer configuration option (default: `false`).
+    This setting allows users to opt for the previous behavior if preferred (set to `true`).
+
 - 4.1.1
   - Upgrade `kafka_protocol` from version 4.1.5 to 4.1.9.
 

--- a/src/brod.erl
+++ b/src/brod.erl
@@ -262,6 +262,7 @@
                            | {offset_reset_policy, brod_consumer:offset_reset_policy()}
                            | {size_stat_window,    non_neg_integer()}
                            | {isolation_level,     brod_consumer:isolation_level()}
+                           | {share_leader_conn,   boolean()}
                            ].
 %% Consumer configuration.
 %%


### PR DESCRIPTION
fixes https://github.com/kafka4beam/brod/issues/577

Introdced `share_leader_conn` consumer config option (default = `false`).
Set to `true` to consume less TCP connections towards Kafka, but may lead to higher fetch latency.
This is because Kafka can ony accumulate messages for the oldest fetch request for each connection, 
later requests behind it may get blocked until `max_wait_time` expires for the oldest one