### PR TITLE
fix: don't crash client if stopping an unknown consumer, stop `brod_consumer` processes when terminating `brod_group_subscriber_v2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- 4.3.1
+  - Fixed `brod_client:stop_consumer` so that it doesn't crash the client process if an unknown consumer is given as argument.
+  - Previously, `brod_group_subscriber_v2` could leave `brod_consumer` processes lingering even after its shutdown.  Now, those processes are terminated.
+
 - 4.3.0
   - Split brod-cli out to a separate project [kafka4beam/brod-cli](https://github.com/kafka4beam/brod-cli)
 

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -388,8 +388,8 @@ handle_call({stop_producer, Topic}, _From, State) ->
   ok = brod_producers_sup:stop_producer(State#state.producers_sup, Topic),
   {reply, ok, State};
 handle_call({stop_consumer, Topic}, _From, State) ->
-  ok = brod_consumers_sup:stop_consumer(State#state.consumers_sup, Topic),
-  {reply, ok, State};
+  Reply = brod_consumers_sup:stop_consumer(State#state.consumers_sup, Topic),
+  {reply, Reply, State};
 handle_call({get_leader_connection, Topic, Partition}, _From, State) ->
   {Result, NewState} = do_get_leader_connection(State, Topic, Partition),
   {reply, Result, NewState};


### PR DESCRIPTION
### Crash prior to fix

```
=ERROR REPORT==== 25-Oct-2024::12:11:26.244821 ===
** Generic server t_double_stop_consumer terminating
** Last message in was {stop_consumer,<<"brod-client-SUITE-topic">>}
** When Server state == {state,t_double_stop_consumer,
                               [{"localhost",9192}],
                               <0.664.0>,[],<0.667.0>,<0.668.0>,
                               [{get_metadata_timeout_seconds,10}],
                               t_double_stop_consumer}
** Reason for termination ==
** {{badmatch,{error,not_found}},
    [{brod_client,handle_call,3,
                  [{file,"/home/thales/dev/emqx/brod/src/brod_client.erl"},
                   {line,391}]},
     {gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,1131}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1160}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}
** Client <0.661.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,240}]},
    {gen_server,call,3,[{file,"gen_server.erl"},{line,415}]},
    {brod_client,safe_gen_call,3,
                 [{file,"/home/thales/dev/emqx/brod/src/brod_client.erl"},
                  {line,979}]},
    {brod_client_SUITE,t_double_stop_consumer,1,
                       [{file,"/home/thales/dev/emqx/brod/test/brod_client_SUITE.erl"},
                        {line,395}]},
    {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1793}]},
    {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1302}]},
    {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1234}]}]

=CRASH REPORT==== 25-Oct-2024::12:11:26.244863 ===
  crasher:
    initial call: brod_client:init/1
    pid: <0.663.0>
    registered_name: t_double_stop_consumer
    exception error: no match of right hand side value {error,not_found}
      in function  brod_client:handle_call/3 (/home/thales/dev/emqx/brod/src/brod_client.erl, line 391)
      in call from gen_server:try_handle_call/4 (gen_server.erl, line 1131)
      in call from gen_server:handle_msg/6 (gen_server.erl, line 1160)
    ancestors: [brod_sup,<0.657.0>]
    message_queue_len: 3
    messages: [{'EXIT',<0.667.0>,shutdown},
                  {'EXIT',<0.668.0>,shutdown},
                  {'EXIT',<0.664.0>,shutdown}]
    links: [<0.658.0>]
    dictionary: [{rand_seed,{#{type => exsss,next => #Fun<rand.0.65977474>,
                                bits => 58,uniform => #Fun<rand.1.65977474>,
                                uniform_n => #Fun<rand.2.65977474>,
                                jump => #Fun<rand.3.65977474>},
                              [52087848521744273|168058237035269794]}}]
    trap_exit: true
    status: running
    heap_size: 1598
    stack_size: 28
    reductions: 2571
  neighbours:

=ERROR REPORT==== 25-Oct-2024::12:11:26.244935 ===
    supervisor: {local,brod_sup}
    errorContext: child_terminated
    reason: {{badmatch,{error,not_found}},
             [{brod_client,handle_call,3,
                           [{file,"/home/thales/dev/emqx/brod/src/brod_client.erl"},
                            {line,391}]},
              {gen_server,try_handle_call,4,
                          [{file,"gen_server.erl"},{line,1131}]},
              {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1160}]},
              {proc_lib,init_p_do_apply,3,
                        [{file,"proc_lib.erl"},{line,241}]}]}
    offender: [{pid,<0.663.0>},
               {id,t_double_stop_consumer},
               {mfargs,{brod_client,start_link,
                                    [[{"localhost",9192}],
                                     t_double_stop_consumer,
                                     [{get_metadata_timeout_seconds,10}]]}},
               {restart_type,{permanent,10}},
               {shutdown,5000},
               {child_type,worker}]
```

### Termination of `brod_consumer` processes

Previously, terminating a `brod_group_subscriber_v2` would leave `brod_consumer` processes started by `brod_client` lingering.  Now, we cleanup those processes upon termination.