### PR TITLE
Remove v prefix from version tags in GitHub URLs for doc links

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,6 +35,7 @@
     , {homepage_url, "https://hexdocs.pm/brod"}
     , {source_url, "https://github.com/kafka4beam/brod"}
     , {source_ref, "master"}
+    , {prefix_ref_vsn_with_v, false}
     , {api_reference, false}
   ]}.
 {hex, [{doc, ex_doc}]}.


### PR DESCRIPTION
Fixes #603