### PR TITLE
Upgrade kafka_protocol from 4.1.9 to 4.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 4.3.2
+   - Upgrade kafka_protocol from 4.1.9 to 4.1.10 for partition leader discover/connect timeout fix.
+
 - 4.3.1
   - Fixed `brod_client:stop_consumer` so that it doesn't crash the client process if an unknown consumer is given as argument.
   - Previously, `brod_group_subscriber_v2` could leave `brod_consumer` processes lingering even after its shutdown.  Now, those processes are terminated.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{kafka_protocol, "4.1.9"}]}.
+{deps, [{kafka_protocol, "4.1.10"}]}.
 {project_plugins, [{rebar3_lint, "~> 3.2.5"}]}.
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [warnings_as_errors, warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.


### PR DESCRIPTION
take the greater value of `connect_timeout` from connection config and `timeout` from request options when trying to discover then connect

- partition-leader
- group-coordinator
- cluster-controller

issue reported: https://github.com/kafka4beam/brod/discussions/602
issue fixed: https://github.com/kafka4beam/kafka_protocol/pull/127