### PR TITLE
Documentation: Fix wrong value for message_type default in brod_group_subscriber_v2

### DIFF
--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -164,7 +164,7 @@
 %%
 %% <li>`message_type': The type of message that is going to be handled
 %% by the callback module. Can be either message or message set.
-%% Optional, defaults to `message'</li>
+%% Optional, defaults to `message_set'</li>
 %%
 %% <li>`init_data': The `term()' that is going to be passed to
 %% `CbModule:init/2' when initializing the subscriber. Optional,


### PR DESCRIPTION
Fixed documentation for default value of message_type in group_subscriber_v2