### PR TITLE
Implement handle_continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - 4.4.1
   - Upgrade `kafka_protocol` from 4.2.3 to 4.2.5 for:
     - `crc32c` performance improvements on ARM.
+  - Replace self messaging in `init` with `handle_continue`
 
 - 4.4.0
   - Support `zstd` compression.

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -61,6 +61,7 @@
         , handle_call/3
         , handle_cast/2
         , handle_info/2
+        , handle_continue/2
         , init/1
         , terminate/2
         ]).
@@ -344,15 +345,15 @@ init({BootstrapEndpoints, ClientId, Config}) ->
   erlang:process_flag(trap_exit, true),
   Tab = ets:new(?ETS(ClientId),
                 [named_table, protected, {read_concurrency, true}]),
-  self() ! init,
+  %% self() ! init,
   {ok, #state{ client_id           = ClientId
              , bootstrap_endpoints = BootstrapEndpoints
              , config              = Config
              , workers_tab         = Tab
-             }}.
+             }, {continue, init}}.
 
 %% @private
-handle_info(init, State0) ->
+handle_continue(init, State0) ->
   Endpoints = State0#state.bootstrap_endpoints,
   State1 = ensure_metadata_connection(State0),
   {ok, ProducersSupPid} = brod_producers_sup:start_link(),
@@ -361,7 +362,9 @@ handle_info(init, State0) ->
                       , producers_sup       = ProducersSupPid
                       , consumers_sup       = ConsumersSupPid
                       },
-  {noreply, State};
+  {noreply, State}.
+
+%% @private
 handle_info({'EXIT', Pid, Reason}, #state{ client_id     = ClientId
                                          , producers_sup = Pid
                                          } = State) ->

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -345,7 +345,6 @@ init({BootstrapEndpoints, ClientId, Config}) ->
   erlang:process_flag(trap_exit, true),
   Tab = ets:new(?ETS(ClientId),
                 [named_table, protected, {read_concurrency, true}]),
-  %% self() ! init,
   {ok, #state{ client_id           = ClientId
              , bootstrap_endpoints = BootstrapEndpoints
              , config              = Config

--- a/src/brod_supervisor3.erl
+++ b/src/brod_supervisor3.erl
@@ -330,7 +330,6 @@ init({SupName, Mod, Args}) ->
         {ok, {SupFlags, StartSpec}} ->
             do_init(SupName, SupFlags, StartSpec, Mod, Args);
         post_init ->
-            %%self() ! {post_init, SupName, Mod, Args},
             {ok, #state{}, {continue, {post_init, SupName, Mod, Args}}};
         ignore ->
             ignore;

--- a/src/brod_supervisor3.erl
+++ b/src/brod_supervisor3.erl
@@ -82,7 +82,7 @@
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         handle_continue/2, terminate/2, code_change/3]).
 -export([try_again_restart/3]).
 
 %%--------------------------------------------------------------------------
@@ -330,8 +330,8 @@ init({SupName, Mod, Args}) ->
         {ok, {SupFlags, StartSpec}} ->
             do_init(SupName, SupFlags, StartSpec, Mod, Args);
         post_init ->
-            self() ! {post_init, SupName, Mod, Args},
-            {ok, #state{}};
+            %%self() ! {post_init, SupName, Mod, Args},
+            {ok, #state{}, {continue, {post_init, SupName, Mod, Args}}};
         ignore ->
             ignore;
         Error ->
@@ -669,6 +669,12 @@ handle_info({delayed_restart, {RestartType, _Reason, Child}}, State) ->
         _What ->
             {noreply, State}
     end;
+
+handle_info(Msg, State) ->
+    error_logger:error_msg("Supervisor received unexpected message: ~p~n",
+                           [Msg]),
+    {noreply, State}.
+
 %% [1] When we receive a delayed_restart message we want to reset the
 %% restarts field since otherwise the MaxT might not have elapsed and
 %% we would just delay again and again. Since a common use of the
@@ -676,7 +682,7 @@ handle_info({delayed_restart, {RestartType, _Reason, Child}}, State) ->
 %% (so that we don't end up bouncing around in non-delayed restarts)
 %% this is important.
 
-handle_info({post_init, SupName, Mod, Args}, State0) ->
+handle_continue({post_init, SupName, Mod, Args}, State0) ->
     Res = case Mod:post_init(Args) of
               {ok, {SupFlags, StartSpec}} ->
                   do_init(SupName, SupFlags, StartSpec, Mod, Args);
@@ -687,12 +693,7 @@ handle_info({post_init, SupName, Mod, Args}, State0) ->
     case Res of
         {ok, NewState} -> {noreply, NewState};
         {stop, Reason} -> {stop, Reason, State0}
-    end;
-
-handle_info(Msg, State) ->
-    error_logger:error_msg("Supervisor received unexpected message: ~p~n",
-                           [Msg]),
-    {noreply, State}.
+    end.
 
 %%
 %% Terminate this server.

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -273,7 +273,7 @@ ack(Pid, Partition, Offset) ->
 %%%_* gen_server callbacks =====================================================
 
 %% @private
--spec init(topic_subscriber_config()) -> {ok, state()}.
+-spec init(topic_subscriber_config()) -> {ok, state(), {continue, any()}}.
 init(Config) ->
   Defaults = #{ message_type      => message_set
               , init_data         => undefined

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -291,7 +291,6 @@ init(Config) ->
   {ok, CommittedOffsets, CbState} = CbModule:init(Topic, InitData),
   ok = brod_utils:assert_client(Client),
   ok = brod_utils:assert_topic(Topic),
-  %%self() ! ?LO_CMD_START_CONSUMER(ConsumerConfig, CommittedOffsets, Partitions),
   State =
     #state{ client       = Client
           , client_mref  = erlang:monitor(process, Client)


### PR DESCRIPTION
Replaced self messaging in inits with handle_continue implementation (introduced in OTP 21 as a solution to [this problem](https://github.com/erlang/otp/pull/1429#issue-224294901)). 
Attempting to avoid race conditions on gen_server startup as there was no guarantee that the message sent from the init function will be the first one processed