### PR TITLE
Support update multiple topics by brod client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 4.4.3
+  - Modify`brod_client:get_metadata` and `brod_client:get_metadata_safe` function for support multiple topics.
+
 - 4.4.2
   - Expanded API version ranges to support Kafka 4.0.0
     ```


### PR DESCRIPTION
Hi, first of all thank you for the work.

For now the `brod_client:get_metadata` and `brod_client:get_metadata_safe` function only support one topic, this PR modify those functions and support update multiple topics metadata.

Any feedback appreciated.