### PR TITLE
fix: `ListGroups` request V3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 env:
-  OTP_VERSION: "27"
+  OTP_VERSION: "27.2"
   REBAR_VERSION: "3.24.0"
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: OTP
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@v1.20.4
         with:
           version-type: strict
           otp-version: ${{ env.OTP_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 4.4.4
+  - Fixed `ListGroups` API request for Kafka Protocol API version 3.
+
 - 4.4.3
   - Modify`brod_client:get_metadata` and `brod_client:get_metadata_safe` function for support multiple topics.
 

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -134,7 +134,12 @@ offset_fetch(Connection, GroupId, Topics0) ->
 -spec list_groups(conn()) -> kpro:req().
 list_groups(Connection) ->
   Vsn = pick_version(list_groups, Connection),
-  kpro:make_request(list_groups, Vsn, []).
+  case Vsn >= 3 of
+    true ->
+      kpro:make_request(list_groups, Vsn, #{tagged_fields => []});
+    false ->
+      kpro:make_request(list_groups, Vsn, [])
+  end.
 
 %% @doc Make a `join_group' request.
 -spec join_group(conn(), kpro:struct()) -> kpro:req().

--- a/test/brod_SUITE.erl
+++ b/test/brod_SUITE.erl
@@ -43,7 +43,7 @@ suite() -> [{timetrap, {minutes, 5}}].
 init_per_suite(Config) ->
   case kafka_test_helper:kafka_version() of
     {0, 9} ->
-      {skip, "no_topic_manaegment_apis"};
+      {skip, "no_topic_management_apis"};
     _ ->
       {ok, _} = application:ensure_all_started(brod),
       Config

--- a/test/brod_consumer_SUITE.erl
+++ b/test/brod_consumer_SUITE.erl
@@ -46,6 +46,7 @@
         , t_subscribe_with_unknown_offset/1
         , t_offset_reset_policy/1
         , t_stop_kill/1
+        , t_smoke_list_groups/1
         ]).
 
 
@@ -883,6 +884,13 @@ t_stop_kill(Config) when is_list(Config) ->
   ok = brod_consumer:stop_maybe_kill(Pid, 100),
   ?WAIT_ONLY({'DOWN', Mref, process, Pid, killed}, ok),
   ok = brod_consumer:stop_maybe_kill(Pid, 100).
+
+%% Smoke test for `ListGroups` API.
+t_smoke_list_groups(Config) when is_list(Config) ->
+  [Endpoint] = ?HOSTS,
+  ConnOpts = kafka_test_helper:client_config(),
+  ?assertMatch({ok, Groups} when is_list(Groups), brod:list_groups(Endpoint, ConnOpts)),
+  ok.
 
 %%%_* Help functions ===========================================================
 


### PR DESCRIPTION
Currently, the v3 version of this request is lacking `tagged_fields`.

```
[2025-07-25 13:35:23,014] ERROR Exception while processing request from 172.100.239.7:9092-172.100.239.2:41464-502 (kafka.network.Processor)
org.apache.kafka.common.errors.InvalidRequestException: Error getting request for apiKey: LIST_GROUPS, apiVersion: 3, connectionId: 172.100.239.7:9092-172.100.239.2:41464-502, listenerName: ListenerName(PLAINTEXT), principal: User:ANONYMOUS
Caused by: java.nio.BufferUnderflowException
	at java.base/java.nio.Buffer.nextGetIndex(Unknown Source)
	at java.base/java.nio.HeapByteBuffer.get(Unknown Source)
	at org.apache.kafka.common.utils.ByteUtils.readUnsignedVarint(ByteUtils.java:146)
	at org.apache.kafka.common.protocol.ByteBufferAccessor.readUnsignedVarint(ByteBufferAccessor.java:63)
	at org.apache.kafka.common.message.ListGroupsRequestData.read(ListGroupsRequestData.java:129)
	at org.apache.kafka.common.message.ListGroupsRequestData.<init>(ListGroupsRequestData.java:80)
	at org.apache.kafka.common.requests.ListGroupsRequest.parse(ListGroupsRequest.java:81)
	at org.apache.kafka.common.requests.AbstractRequest.doParseRequest(AbstractRequest.java:190)
	at org.apache.kafka.common.requests.AbstractRequest.parseRequest(AbstractRequest.java:152)
	at org.apache.kafka.common.requests.RequestContext.parseRequest(RequestContext.java:95)
	at kafka.network.RequestChannel$Request.<init>(RequestChannel.scala:102)
	at kafka.network.Processor.$anonfun$processCompletedReceives$1(SocketServer.scala:1030)
	at java.base/java.util.LinkedHashMap$LinkedValues.forEach(Unknown Source)
	at kafka.network.Processor.processCompletedReceives(SocketServer.scala:1008)
	at kafka.network.Processor.run(SocketServer.scala:893)
	at java.base/java.lang.Thread.run(Unknown Source)
```