### PR TITLE
Enable newer OffsetCommit request versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
     A member fenced by another process using the same `group_instance_id` now
     logs the conflict and retries after `rejoin_delay_seconds` instead of
     crashing and causing a supervisor restart loop.
+  - Expand the supported `OffsetCommit` API range from `{2, 2}` to `{2, 8}`.
+    When brod negotiates v5 or later, `offset_retention_seconds` has no effect
+    because the request no longer includes a per-request retention time. Use
+    the broker-side `offsets.retention.minutes` setting instead. Negotiated
+    versions v2 through v4 continue to use `offset_retention_seconds`.
 
 - 4.5.8
   - Fix a consumer-group coordinator crash when offset commits race with

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{kafka_protocol, "4.3.4"}]}.
+{deps, [{kafka_protocol, "4.3.5"}]}.
 {project_plugins, [{rebar3_lint, "~> 3.2.5"}]}.
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [warnings_as_errors, warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -918,7 +918,7 @@ do_commit_offsets_(#state{ groupId                  = GroupId
         PartitionOffset =
           [ {partition_index, Partition}
           , {committed_offset, Offset + 1} %% +1 since roundrobin_v2 protocol
-          , {committed_leader_epoch, -1}
+          , {committed_leader_epoch, -1} %% -1 = unknown leader epoch
           , {committed_metadata, Metadata}
           ],
         {Topic, PartitionOffset}

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -83,6 +83,7 @@
 -define(STATIC_MEMBERSHIP_MIN_API_VERSIONS,
         [ {join_group, 5}
         , {sync_group, 3}
+        , {offset_commit, 7}
         , {heartbeat, 3}
         ]).
 -define(CALL_MEMBER(MemberPid, EXPR),
@@ -909,6 +910,7 @@ do_commit_offsets_(#state{ groupId                  = GroupId
                          , offset_retention_seconds = OffsetRetentionSecs
                          , acked_offsets            = AckedOffsets
                          } = State) ->
+  StaticMemberID = request_group_instance_id(State),
   Metadata = make_offset_commit_metadata(),
   TopicOffsets0 =
     brod_utils:group_per_key(
@@ -916,6 +918,7 @@ do_commit_offsets_(#state{ groupId                  = GroupId
         PartitionOffset =
           [ {partition_index, Partition}
           , {committed_offset, Offset + 1} %% +1 since roundrobin_v2 protocol
+          , {committed_leader_epoch, -1}
           , {committed_metadata, Metadata}
           ],
         {Topic, PartitionOffset}
@@ -936,6 +939,7 @@ do_commit_offsets_(#state{ groupId                  = GroupId
     [ {group_id, GroupId}
     , {generation_id, GenerationId}
     , {member_id, MemberId}
+    , {group_instance_id, StaticMemberID}
     , {retention_time_ms, Retention}
     , {topics, TopicOffsets}
     ],
@@ -1414,7 +1418,7 @@ supports_static_membership_test() ->
       update_static_membership(RequestedState, Connection)),
     meck:expect(
       brod_kafka_apis, supports_version,
-      fun(_Connection, heartbeat, 3) -> false;
+      fun(_Connection, offset_commit, 7) -> false;
          (_Connection, _API, _Vsn) -> true
       end),
     ?assertNot(supports_static_membership(self())),

--- a/src/brod_kafka_apis.erl
+++ b/src/brod_kafka_apis.erl
@@ -153,7 +153,7 @@ supported_versions() ->
    , fetch => {0, 10}
    , list_offsets => {0, 2}
    , metadata => {0, 2}
-   , offset_commit => {2, 2}
+   , offset_commit => {2, 8}
    , offset_fetch => {1, 2}
    , find_coordinator => {0, 0}
    , join_group => {0, 6}

--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -158,7 +158,7 @@ sync_group(Conn, Fields) ->
   make_req(sync_group, Conn, Fields).
 
 %% @doc Make an `offset_commit' request.
--spec offset_commit(conn(), kpro:struct()) -> kpro:req().
+-spec offset_commit(conn() | vsn(), kpro:struct()) -> kpro:req().
 offset_commit(Conn, Fields) ->
   make_req(offset_commit, Conn, Fields).
 

--- a/test/brod_kafka_apis_tests.erl
+++ b/test/brod_kafka_apis_tests.erl
@@ -67,12 +67,14 @@ no_version_range_intersection_test() ->
 pick_static_membership_versions_test() ->
   Versions =
     #{ sync_group => {0, 4}
+     , offset_commit => {0, 8}
      , heartbeat => {0, 4}
      },
   ?WITH_MECK(
     Versions,
     begin
       ?assertEqual(3, brod_kafka_apis:pick_version(self(), sync_group)),
+      ?assertEqual(8, brod_kafka_apis:pick_version(self(), offset_commit)),
       ?assertEqual(4, brod_kafka_apis:pick_version(self(), heartbeat))
     end).
 
@@ -80,6 +82,7 @@ supports_version_test() ->
   Versions =
     #{ join_group => {0, 6}
      , sync_group => {0, 4}
+     , offset_commit => {0, 8}
      , heartbeat => {0, 4}
      },
   ?WITH_MECK(
@@ -87,16 +90,21 @@ supports_version_test() ->
     begin
       ?assert(brod_kafka_apis:supports_version(self(), join_group, 5)),
       ?assert(brod_kafka_apis:supports_version(self(), sync_group, 3)),
+      ?assert(brod_kafka_apis:supports_version(self(), offset_commit, 7)),
+      ?assert(brod_kafka_apis:supports_version(self(), offset_commit, 8)),
       ?assert(brod_kafka_apis:supports_version(self(), heartbeat, 3)),
       ?assertNot(brod_kafka_apis:supports_version(self(), sync_group, 4))
     end).
 
 unsupported_or_unknown_version_test() ->
   ?WITH_MECK(
-    #{heartbeat => {0, 2}},
+    #{ heartbeat => {0, 2}
+     , offset_commit => {0, 8}
+     },
     begin
       ?assertNot(brod_kafka_apis:supports_version(self(), heartbeat, 3)),
-      ?assertNot(brod_kafka_apis:supports_version(self(), sync_group, 3))
+      ?assertNot(brod_kafka_apis:supports_version(self(), sync_group, 3)),
+      ?assertNot(brod_kafka_apis:supports_version(self(), offset_commit, 9))
     end).
 
 setup(Versions) ->

--- a/test/brod_kafka_request_tests.erl
+++ b/test/brod_kafka_request_tests.erl
@@ -1,0 +1,49 @@
+%%%
+%%%   Copyright (c) 2026 Kafka4beam
+%%%
+%%%   Licensed under the Apache License, Version 2.0 (the "License");
+%%%   you may not use this file except in compliance with the License.
+%%%   You may obtain a copy of the License at
+%%%
+%%%       http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%%   Unless required by applicable law or agreed to in writing, software
+%%%   distributed under the License is distributed on an "AS IS" BASIS,
+%%%   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%%   See the License for the specific language governing permissions and
+%%%   limitations under the License.
+%%%
+
+-module(brod_kafka_request_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kafka_protocol/include/kpro.hrl").
+
+offset_commit_request_test_() ->
+  [ {lists:flatten(io_lib:format("version ~p", [Vsn])),
+     fun() -> assert_offset_commit_request(Vsn) end}
+    || Vsn <- lists:seq(2, 8)
+  ].
+
+assert_offset_commit_request(Vsn) ->
+  Partition =
+    [ {partition_index, 0}
+    , {committed_offset, 1}
+    , {committed_leader_epoch, -1}
+    , {committed_metadata, <<>>}
+    ],
+  Fields =
+    [ {group_id, <<"group">>}
+    , {generation_id, 1}
+    , {member_id, <<"member">>}
+    , {group_instance_id, <<"instance">>}
+    , {retention_time_ms, -1}
+    , {topics,
+       [[ {name, <<"topic">>}
+        , {partitions, [Partition]}
+        ]]}
+    ],
+  Req = brod_kafka_request:offset_commit(Vsn, Fields),
+  ?assertMatch(#kpro_req{api = offset_commit, vsn = Vsn}, Req),
+  Encoded = iolist_to_binary(kpro:encode_request(<<"brod">>, 1, Req)),
+  ?assert(is_binary(Encoded)).

--- a/test/brod_kafka_request_tests.erl
+++ b/test/brod_kafka_request_tests.erl
@@ -26,6 +26,7 @@ offset_commit_request_test_() ->
   ].
 
 assert_offset_commit_request(Vsn) ->
+  GroupInstanceID = <<"unique-offset-commit-group-instance-id">>,
   Partition =
     [ {partition_index, 0}
     , {committed_offset, 1}
@@ -36,7 +37,7 @@ assert_offset_commit_request(Vsn) ->
     [ {group_id, <<"group">>}
     , {generation_id, 1}
     , {member_id, <<"member">>}
-    , {group_instance_id, <<"instance">>}
+    , {group_instance_id, GroupInstanceID}
     , {retention_time_ms, -1}
     , {topics,
        [[ {name, <<"topic">>}
@@ -46,4 +47,7 @@ assert_offset_commit_request(Vsn) ->
   Req = brod_kafka_request:offset_commit(Vsn, Fields),
   ?assertMatch(#kpro_req{api = offset_commit, vsn = Vsn}, Req),
   Encoded = iolist_to_binary(kpro:encode_request(<<"brod">>, 1, Req)),
-  ?assert(is_binary(Encoded)).
+  case Vsn >= 7 of
+    true -> ?assertMatch({_, _}, binary:match(Encoded, GroupInstanceID));
+    false -> ?assertEqual(nomatch, binary:match(Encoded, GroupInstanceID))
+  end.


### PR DESCRIPTION
Follow up to https://github.com/kafka4beam/kafka_protocol/pull/150 where we take advantage of that (and the new version of `kafka_protocol`) to enable newer request versions for `OffsetCommit`.

This in turn enables full support for static membership.

I added a new test file to have some more coverage, lmk if that's fine @zmstone.