### PR TITLE
Fix function_clause crash on stale produce responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+- 4.6.4
+  - Fix a producer `function_clause` crash on stale produce responses. With
+    `partition_onwire_limit` greater than 1, the first response with a retriable
+    error put all requests on wire back in the buffer. The response for the next
+    request then crashed the producer. The producer now ignores responses for
+    requests that are no longer on wire.
+
 - 4.6.3
   - Add `fenced_member_action` for static group members. The default `retry`
     action keeps trying to take back a shared `group_instance_id`. The new

--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -146,7 +146,10 @@
 %%     asynchronously before receiving ACKs from broker.
 %%
 %%     NOTE: setting a number greater than 1 may cause messages being persisted
-%%           in an order different from the order they were produced.</li>
+%%           in an order different from the order they were produced.
+%%           When one message set fails with a retriable error, the producer
+%%           sends all message sets on wire again. Kafka may have already
+%%           persisted some of them, so it can persist those twice.</li>
 %%   <li>`max_batch_size' (in bytes, optional, default = 1M):
 %%
 %%     In case callers are producing faster than brokers can handle (or
@@ -360,28 +363,14 @@ handle_info({msg, Pid, #kpro_rsp{ api = produce
             #state{ connection = Pid
                   , buffer   = Buffer
                   } = State) ->
-  [TopicRsp] = kpro:find(responses, Rsp),
-  Topic = kpro:find(topic, TopicRsp),
-  [PartitionRsp] = kpro:find(partition_responses, TopicRsp),
-  Partition = kpro:find(partition, PartitionRsp),
-  ErrorCode = kpro:find(error_code, PartitionRsp),
-  Offset = kpro:find(base_offset, PartitionRsp),
-  Topic = State#state.topic, %% assert
-  Partition = State#state.partition, %% assert
-  {ok, NewState} =
-    case ?IS_ERROR(ErrorCode) of
-      true ->
-        _ = log_error_code(Topic, Partition, Offset, ErrorCode),
-        Error = {produce_response_error, Topic, Partition,
-                 Offset, ErrorCode},
-        is_retriable(ErrorCode) orelse exit({not_retriable, Error}),
-        NewBuffer = brod_producer_buffer:nack(Buffer, Ref, Error),
-        schedule_retry(State#state{buffer = NewBuffer});
-      false ->
-        NewBuffer = brod_producer_buffer:ack(Buffer, Ref, Offset),
-        maybe_produce(State#state{buffer = NewBuffer})
-    end,
-  {noreply, NewState};
+  case brod_producer_buffer:is_onwire(Buffer, Ref) of
+    true ->
+      %% Check the full active set so ack/nack still reject responses out of order.
+      handle_produce_response(Ref, Rsp, State);
+    false ->
+      %% nack_all removes old references. Their replies can arrive after a retry.
+      {noreply, State}
+  end;
 handle_info(_Info, #state{} = State) ->
   {noreply, State}.
 
@@ -430,6 +419,30 @@ format_status(#{reason := terminate, state := #state{buffer = Buffer} = State} =
 -endif.
 
 %%%_* Internal Functions =======================================================
+
+handle_produce_response(Ref, Rsp, #state{buffer = Buffer} = State) ->
+  [TopicRsp] = kpro:find(responses, Rsp),
+  Topic = kpro:find(topic, TopicRsp),
+  [PartitionRsp] = kpro:find(partition_responses, TopicRsp),
+  Partition = kpro:find(partition, PartitionRsp),
+  ErrorCode = kpro:find(error_code, PartitionRsp),
+  Offset = kpro:find(base_offset, PartitionRsp),
+  Topic = State#state.topic, %% assert
+  Partition = State#state.partition, %% assert
+  {ok, NewState} =
+    case ?IS_ERROR(ErrorCode) of
+      true ->
+        _ = log_error_code(Topic, Partition, Offset, ErrorCode),
+        Error = {produce_response_error, Topic, Partition,
+                 Offset, ErrorCode},
+        is_retriable(ErrorCode) orelse exit({not_retriable, Error}),
+        NewBuffer = brod_producer_buffer:nack(Buffer, Ref, Error),
+        schedule_retry(State#state{buffer = NewBuffer});
+      false ->
+        NewBuffer = brod_producer_buffer:ack(Buffer, Ref, Offset),
+        maybe_produce(State#state{buffer = NewBuffer})
+    end,
+  {noreply, NewState}.
 
 make_send_fun(Topic, Partition, RequiredAcks, AckTimeout, Compression) ->
   ExtraArg = {Topic, Partition, RequiredAcks, AckTimeout, Compression},

--- a/src/brod_producer_buffer.erl
+++ b/src/brod_producer_buffer.erl
@@ -28,6 +28,7 @@
         ]).
 
 -export([ is_empty/1
+        , is_onwire/2
         ]).
 
 -export_type([buf/0]).
@@ -182,6 +183,11 @@ is_empty(#buf{ pending = Pending
   queue:is_empty(Pending) andalso
   queue:is_empty(Buffer) andalso
   Onwire =:= [].
+
+%% @doc Return true if the request attempt is still waiting for a response.
+-spec is_onwire(buf(), reference()) -> boolean().
+is_onwire(#buf{onwire = OnWire}, Ref) ->
+  lists:keymember(Ref, 1, OnWire).
 
 %%%_* Internal functions =======================================================
 

--- a/test/brod_producer_buffer_SUITE.erl
+++ b/test/brod_producer_buffer_SUITE.erl
@@ -131,13 +131,29 @@ t_nack(Config) when is_list(Config) ->
   Buf3 = AddFun(AddFun(Buf2, 2), 3),
   Buf4 = MaybeSend(Buf3),
   Ref1 = ReceiveFun(?LINE, [0, 1]), %% max batch size
-  _Ref = ReceiveFun(?LINE, [2, 3]), %% max onwire is 2
+  Ref2 = ReceiveFun(?LINE, [2, 3]), %% max onwire is 2
+  ?assert(brod_producer_buffer:is_onwire(Buf4, Ref1)),
+  ?assert(brod_producer_buffer:is_onwire(Buf4, Ref2)),
+  ?assertNot(brod_producer_buffer:is_onwire(Buf4, make_ref())),
+  %% ack/nack accept only the head reference. A response that arrives
+  %% out of order must crash the caller, not be ignored.
+  ?assertError(function_clause, AckFun(Buf4, Ref2)),
+  ?assertError(function_clause, NackFun(Buf4, Ref2)),
   Buf5 = NackFun(Buf4, Ref1),       %% re-queue all
+  ?assertNot(brod_producer_buffer:is_onwire(Buf5, Ref1)),
+  ?assertNot(brod_producer_buffer:is_onwire(Buf5, Ref2)),
   Buf6 = MaybeSend(Buf5),           %% as if a scheduled retry
   Ref3 = ReceiveFun(?LINE, [0, 1]), %% receive a max batch
   Ref4 = ReceiveFun(?LINE, [2, 3]), %% another max batch (max onwire is 2)
+  ?assertNot(brod_producer_buffer:is_onwire(Buf6, Ref1)),
+  ?assertNot(brod_producer_buffer:is_onwire(Buf6, Ref2)),
+  ?assert(brod_producer_buffer:is_onwire(Buf6, Ref3)),
+  ?assert(brod_producer_buffer:is_onwire(Buf6, Ref4)),
   Buf7 = AckFun(Buf6, Ref3),
+  ?assertNot(brod_producer_buffer:is_onwire(Buf7, Ref3)),
+  ?assert(brod_producer_buffer:is_onwire(Buf7, Ref4)),
   Buf8 = AckFun(Buf7, Ref4),
+  ?assertNot(brod_producer_buffer:is_onwire(Buf8, Ref4)),
   ?assert(brod_producer_buffer:is_empty(Buf8)).
 
 t_send_fun_error(Config) when is_list(Config) ->

--- a/test/brod_producer_stub_SUITE.erl
+++ b/test/brod_producer_stub_SUITE.erl
@@ -32,6 +32,10 @@
         , t_produce_request_telemetry/1
         , t_retry_on_same_connection/1
         , t_retry_on_kafka_storage_error/1
+        , t_stale_error_before_retry/1
+        , t_stale_success_before_retry/1
+        , t_stale_error_after_retry/1
+        , t_stale_success_after_retry/1
         , t_connection_down_retry/1
         , t_leader_migration/1
         ]).
@@ -44,19 +48,24 @@
 -include("brod_int.hrl").
 
 -define(WAIT(Pattern, Handle, Timeout),
+        ?WAIT_AT(?LINE, Pattern, Handle, Timeout)).
+
+%% Same as ?WAIT, but reports Line on failure. Use this in helpers so the
+%% error points at the caller and not at the helper.
+-define(WAIT_AT(Line, Pattern, Handle, Timeout),
         fun() ->
           receive
             Pattern ->
               Handle;
             Msg ->
               erlang:error({unexpected,
-                            [{line, ?LINE},
+                            [{line, Line},
                              {pattern, ??Pattern},
                              {received, Msg}]})
           after
             Timeout ->
               erlang:error({timeout,
-                            [{line, ?LINE},
+                            [{line, Line},
                              {pattern, ??Pattern}]})
           end
         end()).
@@ -290,6 +299,18 @@ t_retry_on_kafka_storage_error(Config) when is_list(Config) ->
         ok, 2000),
   ok = brod_producer:stop(Producer).
 
+t_stale_error_before_retry(Config) when is_list(Config) ->
+  stale_response(?kafka_storage_error, before_retry).
+
+t_stale_success_before_retry(Config) when is_list(Config) ->
+  stale_response(?no_error, before_retry).
+
+t_stale_error_after_retry(Config) when is_list(Config) ->
+  stale_response(?kafka_storage_error, after_retry).
+
+t_stale_success_after_retry(Config) when is_list(Config) ->
+  stale_response(?no_error, after_retry).
+
 %% This is a typical connection restart scenario:
 %% 0. Start producer allowing two requests on wire
 %% 1. Send first request on wire, but no ack yet
@@ -450,6 +471,131 @@ t_leader_migration(Config) when is_list(Config) ->
 
 %%%_* Help functions ===========================================================
 
+stale_response(ErrorCode, When) ->
+  Tester = self(),
+  meck_module(brod_kafka_request),
+  try
+    meck:expect(brod_client, get_leader_connection,
+                fun(client, <<"topic">>, 0) -> {ok, Tester} end),
+    meck:expect(brod_kafka_request, produce,
+                fun(_, <<"topic">>, 0, Batch, 1, _, no_compression) ->
+                    #kpro_req{api = produce, ref = make_ref(), msg = Batch}
+                end),
+    meck:expect(kpro, request_async,
+                fun(Connection, Req) ->
+                    Connection ! {request_async, Req},
+                    ok
+                end),
+    ProducerConfig = [{required_acks, 1},
+                      {partition_onwire_limit, 2},
+                      {max_batch_size, 1},
+                      {max_retries, 1},
+                      %% The test cancels this timer and sends 'retry' itself.
+                      %% The suite timetrap expires before this timer can fire.
+                      {retry_backoff_ms, 60000}],
+    {ok, Producer} = brod_producer:start_link(client, <<"topic">>, 0,
+                                              ProducerConfig),
+    %% The cleanup below kills the producer. Without unlink, that kill would
+    %% also stop this test process and hide the real failure.
+    unlink(Producer),
+    try
+      Produce = fun(Key) ->
+                    AckCb = fun(Partition, Offset) ->
+                                Tester ! {acked, Key, Partition, Offset}
+                            end,
+                    ok = brod_producer:produce_cb(Producer, Key, Key, AckCb)
+                end,
+      ok = Produce(<<"1">>),
+      {Ref1, Batch1} = receive_produce_request(?LINE, <<"1">>),
+      ok = Produce(<<"2">>),
+      {Ref2, Batch2} = receive_produce_request(?LINE, <<"2">>),
+      ?assertNotEqual(Ref1, Ref2),
+      ok = Produce(<<"3">>),
+      {Buffer0, undefined} = producer_buffer_and_retry(Producer),
+      assert_buffer_counts(Buffer0, 1, 2),
+
+      Producer ! {msg, Tester, fake_rsp(Ref1, <<"topic">>, 0, ?kafka_storage_error)},
+      {Buffer1, RetryRef} = producer_buffer_and_retry(Producer),
+      assert_buffer_counts(Buffer1, 3, 0),
+      ?assert(is_reference(RetryRef)),
+      ?assert(is_integer(erlang:read_timer(RetryRef))),
+      assert_no_producer_events(),
+      StaleRsp = fake_rsp(Ref2, <<"topic">>, 0, ErrorCode, 999),
+      case When of
+        before_retry -> assert_ignored_response(Producer, Tester, StaleRsp);
+        after_retry -> ok
+      end,
+
+      ?assert(is_integer(erlang:cancel_timer(RetryRef))),
+      Producer ! retry,
+      {NewRef1, Batch1} = receive_produce_request(?LINE, <<"1">>),
+      {NewRef2, Batch2} = receive_produce_request(?LINE, <<"2">>),
+      ?assertEqual(4, length(lists:usort([Ref1, Ref2, NewRef1, NewRef2]))),
+      {Buffer2, undefined} = producer_buffer_and_retry(Producer),
+      assert_buffer_counts(Buffer2, 1, 2),
+      case When of
+        before_retry -> ok;
+        after_retry -> assert_ignored_response(Producer, Tester, StaleRsp)
+      end,
+      %% A response from another connection pid is ignored, also for a live request.
+      OtherConnection = spawn(fun() -> ok end),
+      assert_ignored_response(Producer, OtherConnection,
+                              fake_rsp(NewRef1, <<"topic">>, 0, ?no_error, 100)),
+
+      Producer ! {msg, Tester, fake_rsp(NewRef1, <<"topic">>, 0, ?no_error, 100)},
+      ?WAIT({acked, <<"1">>, 0, 100}, ok, 1000),
+      {Ref3, _Batch3} = receive_produce_request(?LINE, <<"3">>),
+      Producer ! {msg, Tester, fake_rsp(NewRef2, <<"topic">>, 0, ?no_error, 101)},
+      ?WAIT({acked, <<"2">>, 0, 101}, ok, 1000),
+      Producer ! {msg, Tester, fake_rsp(Ref3, <<"topic">>, 0, ?no_error, 102)},
+      ?WAIT({acked, <<"3">>, 0, 102}, ok, 1000),
+      {Buffer3, undefined} = producer_buffer_and_retry(Producer),
+      ?assert(brod_producer_buffer:is_empty(Buffer3)),
+      assert_no_producer_events(),
+      %% Duplicate acknowledgements must not call the callbacks again.
+      assert_ignored_response(Producer, Tester, fake_rsp(NewRef1, <<"topic">>, 0)),
+      assert_ignored_response(Producer, Tester, fake_rsp(NewRef2, <<"topic">>, 0)),
+      assert_ignored_response(Producer, Tester, fake_rsp(Ref3, <<"topic">>, 0)),
+      ok = brod_producer:stop(Producer)
+    after
+      MRef = erlang:monitor(process, Producer),
+      exit(Producer, kill),
+      receive {'DOWN', MRef, process, Producer, _} -> ok end
+    end
+  after
+    meck:unload(brod_kafka_request)
+  end.
+
+receive_produce_request(Line, Key) ->
+  ?WAIT_AT(Line,
+           {request_async,
+            #kpro_req{ref = Ref, msg = [#{key := Key, value := Key}] = Batch}},
+           {Ref, Batch}, 1000).
+
+%% Positions follow #state{} in brod_producer.erl (buffer, retry_tref).
+producer_buffer_and_retry(Producer) ->
+  {state, _, _, _, _, _, Buffer, _, RetryRef, _, _} = sys:get_state(Producer),
+  {Buffer, RetryRef}.
+
+%% Positions follow #buf{} in brod_producer_buffer.erl (buffer_count, onwire_count).
+assert_buffer_counts(Buffer, Buffered, OnWire) ->
+  ?assertMatch({buf, _, _, _, _, _, _, _, Buffered, OnWire, _, _, _}, Buffer).
+
+assert_ignored_response(Producer, Connection, Rsp) ->
+  State = sys:get_state(Producer),
+  Producer ! {msg, Connection, Rsp},
+  %% This call follows the response from the same sender. It is a mailbox barrier.
+  ?assertEqual(State, sys:get_state(Producer)),
+  ?assert(is_process_alive(Producer)),
+  assert_no_producer_events().
+
+assert_no_producer_events() ->
+  receive
+    Event -> erlang:error({unexpected_producer_event, Event})
+  after 0 ->
+    ok
+  end.
+
 handle_telemetry_event(Event, Measurements, Metadata, #{pid := Pid}) ->
   Pid ! {telemetry, Event, Measurements, Metadata}.
 
@@ -460,6 +606,9 @@ fake_rsp(Ref, Topic, Partition) ->
   fake_rsp(Ref, Topic, Partition, ?no_error).
 
 fake_rsp(Ref, Topic, Partition, ErrorCode) ->
+  fake_rsp(Ref, Topic, Partition, ErrorCode, -1).
+
+fake_rsp(Ref, Topic, Partition, ErrorCode, Offset) ->
   #kpro_rsp{ api = produce
            , vsn = 0
            , ref = Ref
@@ -468,7 +617,7 @@ fake_rsp(Ref, Topic, Partition, ErrorCode) ->
                       ,{partition_responses,
                         [[{partition, Partition},
                           {error_code, ErrorCode},
-                          {base_offset, -1}
+                          {base_offset, Offset}
                          ]
                         ]}
                       ]


### PR DESCRIPTION
I think this was already described in #419 but we've seen it happen in production a few hundred times so far. We set `partition_onwire_limit` to `5`, for context.

cc @zmstone 